### PR TITLE
[지현기] week3

### DIFF
--- a/css/color.css
+++ b/css/color.css
@@ -1,0 +1,16 @@
+:root {
+  --blue-1: #6D6AFE;
+  --blue-2: #6AE3FE;
+  --red-1: #FF5B56;
+  --black-1: #111322;
+  --black-2: #000000;
+  --white-1: #FFFFFF;
+  --gray-1: #373740;
+  --gray-2: #9FA6B2;
+  --gray-3: #CCD5E3;
+  --gray-4: #E7EFFB;
+  --gray-5: #F0F6FF;
+  --gray-6: #F5F5F5;
+  --gray-7: #373740;
+  --gray-8: #394037;
+}

--- a/css/responsive_index.css
+++ b/css/responsive_index.css
@@ -1,0 +1,177 @@
+@media screen and (min-width: 768px) and (max-width: 1199px) {
+  * {
+    box-sizing: border-box;
+    text-decoration: none;
+  }
+
+  html {
+    font-size: 62.5%;
+  }
+
+  nav {
+    width: 78.2rem;
+    padding: 2rem 3.2rem;
+  }
+
+  .header-section {
+    padding-top: 3.9rem;
+  }
+
+  .header-text {
+    width: 47.2rem;
+    height: 24rem;
+    word-break: keep-all;
+  }
+
+  .img-1 {
+    width: 69.8rem;
+    height: 34.3rem;
+  }
+
+  .main-section {
+    width: auto;
+    height: auto;
+    padding: 5rem 0;
+    gap: 5.1rem;
+  }
+
+  .main-section.first {
+    padding-top: 8rem;
+  }
+
+  .img-2,
+  .img-3,
+  .img-4,
+  .img-5 {
+    width: 38.5rem;
+    height: 31.5rem;
+  }
+
+  .main-text {
+    width: 27.2rem;
+  }
+}
+
+@media screen and (min-width: 375px) and (max-width: 767px) {
+  * {
+    box-sizing: border-box;
+    text-decoration: none;
+  }
+
+  html {
+    font-size: 62.5%;
+  }
+
+  nav {
+    width: 100%;
+    padding: 1.3rem 3.2rem;
+  }
+
+  nav>img {
+    object-fit: cover;
+  }
+
+  .signin {
+    padding: 1rem 1.6rem;
+    font-size: 1.4rem;
+    width: 8rem;
+  }
+
+  .header-section {
+    padding: 2.8rem 3.2rem 0 3.3rem;
+    width: 100%;
+    gap: 2.4rem;
+  }
+
+  .header-text {
+    width: 23.6rem;
+    height: 12.6rem;
+    word-break: keep-all;
+    font-size: 3.2rem;
+    line-height: 4.2rem;
+  }
+
+  .header-section>a {
+    width: 20rem;
+    padding: 1rem 1.6rem;
+    font-size: 1.4rem;
+  }
+
+  .img-1,
+  .img-2,
+  .img-3,
+  .img-4,
+  .img-5 {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  .main-section {
+    flex-direction: column;
+    width: auto;
+    height: auto;
+    padding: 4rem 3.2rem 4.2rem 3.3rem;
+    gap: 2.4rem;
+  }
+
+  .main-section.first {
+    padding-bottom: 3.6rem;
+    padding-top: 4rem;
+  }
+
+  .main-text {
+    width: 100%;
+    gap: 1rem;
+    font-size: 2.4rem;
+    letter-spacing: -0.03rem;
+  }
+
+  .main-section>.main-text {
+    order: 1;
+  }
+
+  .main-section>img {
+    order: 2;
+  }
+
+  .main-text-gradient-1,
+  .main-text-gradient-2,
+  .main-text-gradient-3,
+  .main-text-gradient-4,
+  .main-text-gradient-5 {
+    font-size: 2.4rem;
+    letter-spacing: -0.03rem;
+  }
+
+  .main-text-explanation {
+    word-break: keep-all;
+  }
+
+  footer {
+    margin-top: 4rem;
+  }
+
+  .footer-content {
+    display: grid;
+    grid-template-columns: 18.1rem 1fr 11.6rem;
+    grid-template-rows: 2rem 6rem 1.8rem;
+    padding: 3.2rem 3.2rem;
+  }
+
+  .codeit {
+    grid-column: 1/2;
+    grid-row: 3/4;
+    justify-self: start;
+  }
+
+  .policy-faq {
+    grid-column: 1/2;
+    grid-row: 1/2;
+  }
+
+  .icon {
+    grid-column: 3/4;
+    grid-row: 1/2;
+  }
+}

--- a/css/responsive_sign.css
+++ b/css/responsive_sign.css
@@ -1,0 +1,30 @@
+@media screen and (min-width: 375px) and (max-width: 767px) {
+  * {
+    box-sizing: border-box;
+    text-decoration: none;
+  }
+
+  html {
+    font-size: 62.5%;
+  }
+
+  main {
+    padding: 0 3.2rem;
+    width: 100%;
+  }
+
+  .normal-signin,
+  .normal-signup,
+  .signin,
+  .signup,
+  .password-input,
+  .password-confirm-input,
+  input,
+  .signin-button,
+  .signup-button,
+  .social-signin,
+  .social-signup {
+    width: 100%;
+    max-width: 40rem;
+  }
+}

--- a/css/style.css
+++ b/css/style.css
@@ -1,5 +1,7 @@
 @import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.8/dist/web/static/pretendard.css");
 
+@import url(./color.css);
+
 * {
   box-sizing: border-box;
   text-decoration: none;
@@ -15,7 +17,7 @@ header {
   flex-direction: column;
   align-items: center;
   width: 100%;
-  background-color: #F0F6FF;
+  background-color: var(--gray-5);
 }
 
 nav {
@@ -26,7 +28,7 @@ nav {
   max-width: 192rem;
   padding: 2rem 20rem;
   position: fixed;
-  background-color: #F0F6FF;
+  background-color: var(--gray-5);
 }
 
 .signin {
@@ -35,12 +37,12 @@ nav {
   align-items: center;
   padding: 1.6rem 2rem;
   width: 12.8rem;
-  color: #F5F5F5;
+  color: var(--gray-6);
   font-family: pretendard;
   font-size: 1.8rem;
   font-weight: 600;
   border-radius: 0.8rem;
-  background: linear-gradient(91deg, #6D6AFE 0.12%, #6AE3FE 101.84%);
+  background: linear-gradient(91deg, var(--blue-1) 0.12%, var(--blue-2) 101.84%);
 }
 
 .header-section {
@@ -64,7 +66,7 @@ nav {
 }
 
 .header-text-gradient {
-  background: linear-gradient(91deg, #6D6AFE 17.28%, #FF9F9F 74.98%);
+  background: linear-gradient(91deg, var(--blue-1) 17.28%, #FF9F9F 74.98%);
   background-clip: text;
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
@@ -76,7 +78,7 @@ nav {
   width: 35rem;
   padding: 1.6rem 2rem;
   border-radius: 0.8rem;
-  background: linear-gradient(91deg, #6D6AFE 0.12%, #6AE3FE 101.84%);
+  background: linear-gradient(91deg, var(--blue-1) 0.12%, #6AE3FE 101.84%);
   color: #F5F5F5;
   font-family: Pretendard;
   font-size: 18px;
@@ -191,7 +193,7 @@ footer {
   justify-content: center;
   margin-top: 12rem;
   width: 100%;
-  background-color: #111322;
+  background-color: var(--black-1);
 }
 
 .footer-content {

--- a/css/style.css
+++ b/css/style.css
@@ -50,8 +50,8 @@ nav {
   flex-direction: column;
   justify-content: flex-end;
   align-items: center;
-  width: 192rem;
-  padding: 7rem 36rem 0;
+  max-width: 192rem;
+  padding-top: 7rem;
   gap: 4rem;
   margin-top: 9rem;
 }
@@ -96,11 +96,12 @@ main {
 }
 
 .main-section {
-  width: 192rem;
+  max-width: 192rem;
   height: 62rem;
-  padding: 5rem 46.1rem;
+  padding: 5rem 0;
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 15.7rem;
 }
 

--- a/css/style_signin.css
+++ b/css/style_signin.css
@@ -1,21 +1,6 @@
 @import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.8/dist/web/static/pretendard.css");
 
-:root {
-  --blue-1: #6D6AFE;
-  --blue-2: #6AE3FE;
-  --red-1: #FF5B56;
-  --black-1: #111322;
-  --black-2: #000000;
-  --white-1: #FFFFFF;
-  --gray-1: #373740;
-  --gray-2: #9FA6B2;
-  --gray-3: #CCD5E3;
-  --gray-4: #E7EFFB;
-  --gray-5: #F0F6FF;
-  --gray-6: #F5F5F5;
-  --gray-7: #373740;
-  --gray-8: #394037;
-}
+@import url(./color.css);
 
 * {
   box-sizing: border-box;
@@ -136,7 +121,7 @@ input {
 
 input:focus {
   outline: none;
-  border: 0.2rem solid var(--blue-1);
+  border: 0.1rem solid var(--blue-1);
 }
 
 .password {
@@ -144,11 +129,13 @@ input:focus {
 }
 
 .eye-on {
+  background: url("../img/eye-on.svg");
   position: absolute;
   width: 1.6rem;
   height: 1.6rem;
   right: 2.3rem;
   bottom: 2.3rem;
+  border: 0;
 }
 
 .signin-button {
@@ -165,6 +152,7 @@ input:focus {
   border-radius: 0.8rem;
   background: linear-gradient(91deg, var(--blue-1) 0.12%, var(--blue-2) 101.84%);
   border: 0;
+  cursor: pointer;
 }
 
 .social-signin {

--- a/css/style_signup.css
+++ b/css/style_signup.css
@@ -1,21 +1,6 @@
 @import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.8/dist/web/static/pretendard.css");
 
-:root {
-  --blue-1: #6D6AFE;
-  --blue-2: #6AE3FE;
-  --red-1: #FF5B56;
-  --black-1: #111322;
-  --black-2: #000000;
-  --white-1: #FFFFFF;
-  --gray-1: #373740;
-  --gray-2: #9FA6B2;
-  --gray-3: #CCD5E3;
-  --gray-4: #E7EFFB;
-  --gray-5: #F0F6FF;
-  --gray-6: #F5F5F5;
-  --gray-7: #373740;
-  --gray-8: #394037;
-}
+@import url(./color.css);
 
 * {
   box-sizing: border-box;
@@ -61,13 +46,13 @@ main {
   height: 3.8rem;
 }
 
-.signup-link {
+.signin-link {
   display: flex;
   align-items: flex-start;
   gap: 0.8rem;
 }
 
-.signup-link>span {
+.signin-link>span {
   color: var(--black-1);
   font-family: Pretendard;
   font-size: 1.6rem;
@@ -76,7 +61,7 @@ main {
   line-height: 2.4rem;
 }
 
-.signup-link>a {
+.signin-link>a {
   color: var(--blue-1);
   font-family: Pretendard;
   font-size: 1.6rem;
@@ -133,7 +118,7 @@ input {
 
 input:focus {
   outline: none;
-  border: 0.2rem solid var(--blue-1);
+  border: 0.1rem solid var(--blue-1);
 }
 
 .password {
@@ -141,11 +126,13 @@ input:focus {
 }
 
 .eye-on {
+  background: url("../img/eye-on.svg");
   position: absolute;
   width: 1.6rem;
   height: 1.6rem;
   right: 2.3rem;
   bottom: 2.3rem;
+  border: 0;
 }
 
 .signup-button {
@@ -162,6 +149,7 @@ input:focus {
   border-radius: 0.8rem;
   background: linear-gradient(91deg, var(--blue-1) 0.12%, var(--blue-2) 101.84%);
   border: 0;
+  cursor: pointer;
 }
 
 .social-signup {

--- a/index.html
+++ b/index.html
@@ -5,8 +5,30 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Linkbrary</title>
+  <!-- facebook -->
+  <meta property="og:type" content="website">
+  <meta property="image"
+    content="https://unsplash.com/ko/%EC%82%AC%EC%A7%84/%EB%8F%84%EC%84%9C%EA%B4%80-%EC%82%AC%EC%A7%84-I1oL89qxefc?utm_content=creditShareLink&utm_medium=referral&utm_source=unsplash">
+  <meta property="og:url" content="https://linkbrary.com/">
+  <meta property="og:title" content="Linkbrary">
+  <meta property="og:description" content="세상의 모든 정보를 쉽게 저장하고 관리해 보세요">
+  <!-- twitter -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:image"
+    content="https://unsplash.com/ko/%EC%82%AC%EC%A7%84/%EB%8F%84%EC%84%9C%EA%B4%80-%EC%82%AC%EC%A7%84-I1oL89qxefc?utm_content=creditShareLink&utm_medium=referral&utm_source=unsplash">
+  <meta name="twitter:url" content="https://linkbrary.com/">
+  <meta name="twitter:title" content="Linkbrary">
+  <meta name="twitter:description" content="세상의 모든 정보를 쉽게 저장하고 관리해 보세요">
+  <!-- kakaotalk -->
+  <meta property="og:type" content="website">
+  <meta property="og:image"
+    content="https://unsplash.com/ko/%EC%82%AC%EC%A7%84/%EB%8F%84%EC%84%9C%EA%B4%80-%EC%82%AC%EC%A7%84-I1oL89qxefc?utm_content=creditShareLink&utm_medium=referral&utm_source=unsplash">
+  <meta property="og:url" content="https://linkbrary.com/">
+  <meta property="og:title" content="Linkbrary">
+  <meta property="og:description" content="세상의 모든 정보를 쉽게 저장하고 관리해 보세요">
   <link rel="stylesheet" href="./css/reset.css">
   <link rel="stylesheet" href="./css/style.css">
+  <link rel="stylesheet" href="./css/responsive_index.css">
 </head>
 
 <body>

--- a/index.html
+++ b/index.html
@@ -17,8 +17,7 @@
     </nav>
     <section class="header-section">
       <div class="header-text">
-        <span class="header-text-gradient">세상의 모든 정보</span>를<br>
-        쉽게 저장하고 관리해 보세요
+        <span class="header-text-gradient">세상의 모든 정보</span>를<br>쉽게 저장하고 관리해 보세요
       </div>
       <a class="signup" href="./signup.html">링크 추가하기</a>
       <img class="img-1" src="./img/img1.png" alt="img.1">

--- a/signin.html
+++ b/signin.html
@@ -7,6 +7,7 @@
   <title>SignIn</title>
   <link rel="stylesheet" href="./css/reset.css">
   <link rel="stylesheet" href="./css/style_signin.css">
+  <link rel="stylesheet" href="./css/responsive_sign.css">
 </head>
 
 <body>

--- a/signin.html
+++ b/signin.html
@@ -26,8 +26,10 @@
         </div>
         <div class="password">
           <label for="password">비밀번호</label>
-          <input id="password" type="password">
-          <img class="eye-on" src="./img/eye-on.svg" alt="eye-on">
+          <div class="password-input">
+            <input id="password" type="password">
+            <button class="eye-on" type="button"></button>
+          </div>
         </div>
         <button class="signin-button">로그인</button>
       </form>

--- a/signup.html
+++ b/signup.html
@@ -7,6 +7,7 @@
   <title>SignUp</title>
   <link rel="stylesheet" href="./css/reset.css">
   <link rel="stylesheet" href="./css/style_signup.css">
+  <link rel="stylesheet" href="./css/responsive_sign.css">
 </head>
 
 <body>

--- a/signup.html
+++ b/signup.html
@@ -14,7 +14,7 @@
     <div class="normal-signup">
       <div class="signup-header">
         <a class="logo" href="./index.html"><img src="./img/logo.svg" alt="logo"></a>
-        <div class="signup-link">
+        <div class="signin-link">
           <span>이미 회원이신가요?</span>
           <a href="./signin.html">로그인 하기</a>
         </div>
@@ -26,13 +26,17 @@
         </div>
         <div class="password">
           <label for="password">비밀번호</label>
-          <input id="password" type="password">
-          <img class="eye-on" src="./img/eye-on.svg" alt="eye-on">
+          <div class="password-input">
+            <input id="password" type="password">
+            <button class="eye-on" type="button"></button>
+          </div>
         </div>
         <div class="password confirm">
-          <label for="password">비밀번호 확인</label>
-          <input id="password-confirm" type="password">
-          <img class="eye-on" src="./img/eye-on.svg" alt="eye-on">
+          <label for="password-confirm">비밀번호 확인</label>
+          <div class="password-confirm-input">
+            <input id="password-confirm" type="password">
+            <button class="eye-on" type="button"></button>
+          </div>
         </div>
         <button class="signup-button">회원가입</button>
       </form>


### PR DESCRIPTION
## 요구사항

### 기본

- [x] [기본] 브라우저에 현재 보이는 화면의 영역(viewport) 너비를 기준으로 분기되는 반응형 디자인을 적용했나요?

- [x] PC: 1200px 이상
Tablet: 768px 이상 ~ 1199px 이하
Mobile: 375px 이상 ~ 767px 이하
375px 미만 사이즈의 디자인은 고려하지 않습니다

- [x] [랜딩 페이지] 페이스북, 카카오톡, 디스코드, 트위터 등 SNS에서 Linkbrary 랜딩 페이지(“/”) 공유 시 미리보기를 볼 수 있도록 랜딩 페이지 메타 태그를 설정했나요?


- [x] [랜딩 페이지] 미리보기에서 제목은 “Linkbrary”, 설명은 “세상의 모든 정보를 쉽게 저장하고 관리해 보세요”로 설정했나요?


- [x] [랜딩 페이지] 주소와 이미지는 자유롭게 설정했나요?


- [x] [랜딩 페이지] Tablet 사이즈에서 화면의 너비가 1199px 이하로 작아질 때 “Linkbrary” 로고와 “로그인” 버튼 사이의 간격은 변하지 않게 고정값으로 유지하되 좌우 여백이 줄어드나요?


- [x] [랜딩 페이지] Tablet 사이즈에서 최소 좌우 여백은 “Linkbrary” 로고의 왼쪽에 여백 32px, “로그인” 버튼 오른쪽 여백 32px을 유지하고“Linkbrary” 로고와 “로그인" 버튼의 간격이 가까워지나요?


- [x] [랜딩 페이지] PC, Tablet 사이즈의 이미지 크기는 고정값을 사용했나요?


- [x] [랜딩 페이지] Mobile 사이즈의 이미지는 좌우 여백 32px을 제외하고 이미지 영역이 꽉 차나요?
(이때 가로가 커지는 비율에 맞춰 세로도 커져야 합니다.)


- [x] [랜딩 페이지] Mobile 사이즈 너비가 커지면, “Privacy Policy”, “FAQ”, “codeit-2023”이 있는 영역과 SNS 아이콘들이 있는 영역의 간격이 커지나요?


- [x] [로그인, 회원가입 페이지] Tablet 사이즈에서 디자인은 PC사이즈와 동일한가요?


- [x] [로그인, 회원가입 페이지] Mobile 사이즈에서 좌우 여백 32px 제외하고 내부 요소들이 너비를 모두 차지하나요?


- [x] [로그인, 회원가입 페이지] Mobile 사이즈에서 내부 요소들의 너비는 기기의 너비가 커지는 만큼 커지지만 400px을 넘지 않나요?



### 심화
- [ ] [심화] 팀원의 위클리 미션 PR에 코드 리뷰를 남겼나요?


- [ ] [심화] 랜딩 페이지 Mobile 사이즈에서 제품 소개 영역의 순서를 제목, 설명, 이미지 => 제목, 이미지, 설명 순서로 변경했나요?

## 주요 변경사항

- 3주차 위클리 미션 수행
- 3주차 요구사항에 따라 코드를 작성하고 난 후 2주차 미션에서 요소들에 좌우 padding값을 준 부분 때문에 Tablet과 Mobile 사이즈에서 화면이 꽉 차게 보이지 않아 2주차 style.css 파일에서 해당 부분 수정했습니다.


## 스크린샷
<랜딩페이지 Tablet 사이즈>
![Tablet](https://github.com/codeit-bootcamp-frontend/2-Weekly-Mission/assets/140484169/23e1b509-f19a-465f-a285-88cd6ca2c39d)
<랜딩페이지 Mobile 사이즈>
![Mobile](https://github.com/codeit-bootcamp-frontend/2-Weekly-Mission/assets/140484169/f4207fd8-9f5d-4569-a459-9aedc1ecae88)
<로그인페이지 Tablet 사이즈>
![Tablet_signin](https://github.com/codeit-bootcamp-frontend/2-Weekly-Mission/assets/140484169/b208890d-ebab-4759-94e8-777a2974f67d)
<로그인페이지 Mobile 사이즈>
![Mobile_siginin](https://github.com/codeit-bootcamp-frontend/2-Weekly-Mission/assets/140484169/2eb88e5f-e3db-4e21-96c4-6358af476c6e)
<회원가입페이지 Tablet 사이즈>
![Tablet_siginup](https://github.com/codeit-bootcamp-frontend/2-Weekly-Mission/assets/140484169/323c9ea5-f2b6-42b0-b053-722b556978a7)
<회원가입페이지 Mobile 사이즈>
![Mobile_siginup](https://github.com/codeit-bootcamp-frontend/2-Weekly-Mission/assets/140484169/992ec73c-f628-44e9-b1ac-5ad1fd525d72)


## 멘토에게

- 메타태그를 설정하긴 했는데 잘 적용됐는지 확인하는 방법이 궁금합니다
 
- "3주차 심화 요구사항에서 랜딩 페이지 Mobile 사이즈에서 제품 소개 영역의 순서를 제목, 설명, 이미지 => 제목, 이미지, 설명 순서로 변경했나요?" 부분을 해결하려고 Css order 속성을 사용했습니다. 그런데 2주차 html에서 제목과 설명 요소를 div 태그로 묶어놨기 때문에 (제목+설명) (이미지) 의 순서로 밖에 해결하지 못했습니다. div 태그로 묶인 부분을 풀고 각각 order 속성을 주면 해결할 수 있지만 그렇게 되면 해당 div 태그에 적용했던 css 부분을 수정해야 하기 때문에 (제목+설명) (이미지) 의 순서에서 설명 요소만 position 속성으로 이미지 요소 밑으로 위치를 바꿔보고자 했으나 해결하지 못했습니다. 가급적 html을 수정하지 않고 해결하고 싶은데 혹시 방법이 있으면 피드백 부탁 드립니다.

