### PR TITLE
[윤현지] Week4

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,12 +7,12 @@
     <meta name="title" content="Linkbrary" />
     <meta name="description" content="세상의 모든 정보를 쉽게 저장하고 관리해 보세요" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://linkbrary.com" />
+    <meta property="og:url" content="https://linkbrary-project.netlify.app/" />
     <meta property="og:title" content="Linkbrary" />
     <meta property="og:description" content="세상의 모든 정보를 쉽게 저장하고 관리해 보세요" />
     <meta property="og:image" content="./images/linkbrary.jpg" />
     <meta property="twitter:card" content="summary_large_image" />
-    <meta property="twitter:url" content="https://linkbrary.com" />
+    <meta property="twitter:url" content="https://linkbrary-project.netlify.app/" />
     <meta property="twitter:title" content="Linkbrary" />
     <meta property="twitter:description" content="세상의 모든 정보를 쉽게 저장하고 관리해 보세요" />
     <meta property="twitter:image" content="./images/linkbrary.jpg" />

--- a/signin.html
+++ b/signin.html
@@ -58,7 +58,7 @@
         <div class="social-text">
           소셜 로그인
         </div>
-        <div class="social-logo">
+        <div class="social-logo-container">
           <a href="https://www.google.com">
             <img src="./images/google.svg" alt="google 홈페이지로 연결된 google 로고" />
           </a>

--- a/signin.html
+++ b/signin.html
@@ -33,10 +33,12 @@
           <div class="form-container">
             <label>이메일</label>
             <input
+            id="email"
             name="username"
             type="text"
             placeholder=" "
             />
+            <span class="error-massage"></span>
           </div>
           <div class="form-container">
             <label>비밀번호</label>
@@ -68,5 +70,6 @@
         </div>
       </div>
     </div>
+  <script src="signin.js"></script>
   </body>
 </html>

--- a/signin.html
+++ b/signin.html
@@ -72,6 +72,6 @@
         </div>
       </div>
     </div>
-  <script src="signin.js"></script>
+    <script src="signin.js"></script>
   </body>
 </html>

--- a/signin.html
+++ b/signin.html
@@ -50,7 +50,7 @@
               placeholder=" "
               />
               <span class="error-massage"></span>
-              <img class="eyeoff-icon" src="./images/eye-off.png" alt="비밀번호 가리기 icon">
+              <img class="eye-icon" src="./images/eye-off.png" alt="비밀번호 가리기 icon">
             </div>
           </div>
         </form>

--- a/signin.html
+++ b/signin.html
@@ -44,10 +44,12 @@
             <label>비밀번호</label>
             <div class="input-container">
               <input
+              id="password"
               name="password"
               type="password"
               placeholder=" "
               />
+              <span class="error-massage"></span>
               <img class="eyeoff-icon" src="./images/eye-off.png" alt="비밀번호 가리기 icon">
             </div>
           </div>

--- a/signin.js
+++ b/signin.js
@@ -1,0 +1,21 @@
+//이메일 input에서 focus out 할 때
+//값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보입니다
+
+const emailInput = document.getElementById("email");
+const emailErrorMessage = emailInput.nextElementSibling;
+
+function blankEmail(event) {
+  if (event.target.value === ""){
+    event.target.classList.add("input-error");
+    emailErrorMessage.textContent = "이메일을 입력해주세요.";
+  } else {
+    event.target.classList.remove("input-error");
+  }
+}
+
+function resetEmailInput(event) {
+  emailErrorMessage.textContent = "";
+}
+
+emailInput.addEventListener("focusout", blankEmail);
+emailInput.addEventListener("focusin", resetEmailInput);

--- a/signin.js
+++ b/signin.js
@@ -82,3 +82,15 @@ function testLogin(event) {
 }
 
 loginButton.addEventListener("click", testLogin)
+
+//6. 공통: 비밀번호 input에서 focus out 할 때
+//값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지가 보입니다.
+
+function blankPassword(event) {
+  if (event.target.value === ""){
+    event.target.classList.add("input-error");
+    passwordErrorMessage.textContent = "비밀번호를 입력해주세요.";
+  }
+}
+
+passwordInput.addEventListener("focusout", blankPassword);

--- a/signin.js
+++ b/signin.js
@@ -1,4 +1,4 @@
-//이메일 input에서 focus out 할 때
+//1. 공통: 이메일 input에서 focus out 할 때
 //값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보입니다
 
 const emailInput = document.getElementById("email");
@@ -19,3 +19,17 @@ function resetEmailInput(event) {
 
 emailInput.addEventListener("focusout", blankEmail);
 emailInput.addEventListener("focusin", resetEmailInput);
+
+//2. 공통: 이메일 input에서 focus out 할 때, 
+//이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보입니다
+
+const emailPattern = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+
+function invalidEmail(event) {
+  if (!(event.target.value === "") && !(emailPattern.test(event.target.value))){
+    event.target.classList.add("input-error");
+    emailErrorMessage.textContent = "올바른 이메일 주소가 아닙니다.";
+  }
+}
+
+emailInput.addEventListener("focusout", invalidEmail);

--- a/signin.js
+++ b/signin.js
@@ -69,3 +69,16 @@ function resetPasswordInput(event) {
 
 passwordInput.addEventListener("focusout", invalidPassword);
 passwordInput.addEventListener("focusin", resetPasswordInput);
+
+//5. 로그인 페이지
+//이메일: test@codeit.com, 비밀번호: codeit101 으로 로그인 시도경우, “/folder” 페이지로 이동합니다.
+
+const loginButton = document.querySelector(".login-button");
+
+function testLogin(event) {
+  if (emailInput.value === "test@codeit.com" && passwordInput.value === "codeit101") {
+    loginButton.href = "/folder";
+  }
+}
+
+loginButton.addEventListener("click", testLogin)

--- a/signin.js
+++ b/signin.js
@@ -33,3 +33,15 @@ function invalidEmail(event) {
 }
 
 emailInput.addEventListener("focusout", invalidEmail);
+
+//3. 공통: 이메일 input에서 focus out 일 때
+//input 값이 test@codeit.com 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보입니다.
+
+function duplicateEmail(event) {
+  if (event.target.value === "test@codeit.com"){
+    event.target.classList.add("input-error");
+    emailErrorMessage.textContent = "이미 사용 중인 이메일입니다.";
+  }
+}
+
+emailInput.addEventListener("focusout", duplicateEmail);

--- a/signin.js
+++ b/signin.js
@@ -100,3 +100,23 @@ function blankPassword(event) {
 }
 
 passwordInput.addEventListener("focusout", blankPassword);
+
+//12. 공통(심화): 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 합니다.
+//비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이도록 합니다.
+
+const passwordIcon =passwordInput.parentElement.lastElementChild;
+
+function showPassword(event) {
+  event.target.classList.toggle("eye-on");
+  if (event.target.classList.contains("eye-on")) {
+    event.target.parentElement.firstElementChild.type = "text";
+    event.target.src = "./images/eye-on.png";
+    event.target.alt="비밀번호 보이기 icon";
+  } else {
+    event.target.parentElement.firstElementChild.type = "password";
+    event.target.src = "./images/eye-off.png";
+    event.target.alt="비밀번호 가리기 icon";
+  }
+}
+
+passwordIcon.addEventListener("click", showPassword);

--- a/signin.js
+++ b/signin.js
@@ -23,7 +23,7 @@ emailInput.addEventListener("focusin", resetEmailInput);
 //2. 공통: 이메일 input에서 focus out 할 때, 
 //이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보입니다
 
-const emailPattern = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+const emailPattern = /^[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/i;
 
 function invalidEmail(event) {
   if (!(event.target.value === "") && !(emailPattern.test(event.target.value))){

--- a/signin.js
+++ b/signin.js
@@ -70,14 +70,20 @@ function resetPasswordInput(event) {
 passwordInput.addEventListener("focusout", invalidPassword);
 passwordInput.addEventListener("focusin", resetPasswordInput);
 
-//5. 로그인 페이지
+//5. 7. 로그인 페이지
 //이메일: test@codeit.com, 비밀번호: codeit101 으로 로그인 시도경우, “/folder” 페이지로 이동합니다.
+//이외의 로그인 시도의 경우 이메일, 비밀번호 input에 빨강색 테두리와 각각의 input아래에 “이메일을 확인해주세요.”, “비밀번호를 확인해주세요.” 빨강색 에러 메세지가 보입니다.
 
 const loginButton = document.querySelector(".login-button");
 
 function testLogin(event) {
   if (emailInput.value === "test@codeit.com" && passwordInput.value === "codeit101") {
     loginButton.href = "/folder";
+  } else {
+    emailInput.classList.add("input-error");
+    emailErrorMessage.textContent = "이메일을 확인해주세요.";
+    passwordInput.classList.add("input-error");
+    passwordErrorMessage.textContent = "비밀번호를 확인해주세요.";
   }
 }
 

--- a/signin.js
+++ b/signin.js
@@ -87,7 +87,7 @@ function testLogin(event) {
   }
 }
 
-loginButton.addEventListener("click", testLogin)
+loginButton.addEventListener("click", testLogin);
 
 //6. 공통: 비밀번호 input에서 focus out 할 때
 //값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지가 보입니다.

--- a/signin.js
+++ b/signin.js
@@ -45,3 +45,27 @@ function duplicateEmail(event) {
 }
 
 emailInput.addEventListener("focusout", duplicateEmail);
+
+//4. 공통: 비밀번호 input에서 focus out 할 때
+//값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보입니다.
+
+const passwordInput = document.getElementById("password");
+const passwordErrorMessage = passwordInput.nextElementSibling;
+
+const passwordPattern = /^(?=.*[a-zA-Z])(?=.*\d).{8,}$/;
+
+function invalidPassword(event) {
+  if (!passwordPattern.test(event.target.value)){
+    event.target.classList.add("input-error");
+    passwordErrorMessage.textContent = "비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.";
+  } else {
+    event.target.classList.remove("input-error");
+  }
+}
+
+function resetPasswordInput(event) {
+  passwordErrorMessage.textContent = "";
+}
+
+passwordInput.addEventListener("focusout", invalidPassword);
+passwordInput.addEventListener("focusin", resetPasswordInput);

--- a/signup.html
+++ b/signup.html
@@ -69,7 +69,7 @@
         <div class="social-text">
           다른 방식으로 가입하기
         </div>
-        <div class="social-logo">
+        <div class="social-logo-container">
           <a href="https://www.google.com">
             <img src="./images/google.svg" alt="google 홈페이지로 연결된 google 로고" />
           </a>

--- a/signup.html
+++ b/signup.html
@@ -46,11 +46,11 @@
               <input
               id="password"
               name="password"
-              type="text"
+              type="password"
               placeholder=" "
               />
               <span class="error-massage"></span>
-              <img class="eyeon-icon" src="./images/eye-on.png" alt="비밀번호 가리기 icon">
+              <img class="eye-icon" src="./images/eye-off.png" alt="비밀번호 가리기 icon">
             </div>
           </div>
           <div class="form-container">
@@ -59,11 +59,11 @@
               <input
               id="check-password"
               name="password"
-              type="text"
+              type="password"
               placeholder=" "
               />
               <span class="error-massage"></span>
-              <img class="eyeon-icon" src="./images/eye-on.png" alt="비밀번호 가리기 icon">
+              <img class="eye-icon" src="./images/eye-off.png" alt="비밀번호 가리기 icon">
             </div>
           </div>
         </form>

--- a/signup.html
+++ b/signup.html
@@ -57,10 +57,12 @@
             <label>비밀번호 확인</label>
             <div class="input-container">
               <input
+              id="check-password"
               name="password"
               type="text"
               placeholder=" "
               />
+              <span class="error-massage"></span>
               <img class="eyeon-icon" src="./images/eye-on.png" alt="비밀번호 가리기 icon">
             </div>
           </div>

--- a/signup.html
+++ b/signup.html
@@ -33,19 +33,23 @@
           <div class="form-container">
             <label>이메일</label>
             <input
+            id="email"
             name="username"
             type="text"
             placeholder=" "
             />
+            <span class="error-massage"></span>
           </div>
           <div class="form-container">
             <label>비밀번호</label>
             <div class="input-container">
               <input
+              id="password"
               name="password"
               type="text"
               placeholder=" "
               />
+              <span class="error-massage"></span>
               <img class="eyeon-icon" src="./images/eye-on.png" alt="비밀번호 가리기 icon">
             </div>
           </div>
@@ -79,5 +83,6 @@
         </div>
       </div>
     </div>
+    <script src="signup.js"></script>
   </body>
 </html>

--- a/signup.js
+++ b/signup.js
@@ -1,0 +1,83 @@
+//1. 공통: 이메일 input에서 focus out 할 때
+//값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보입니다
+
+const emailInput = document.getElementById("email");
+const emailErrorMessage = emailInput.nextElementSibling;
+
+function blankEmail(event) {
+  if (event.target.value === ""){
+    event.target.classList.add("input-error");
+    emailErrorMessage.textContent = "이메일을 입력해주세요.";
+  } else {
+    event.target.classList.remove("input-error");
+  }
+}
+
+function resetEmailInput(event) {
+  emailErrorMessage.textContent = "";
+}
+
+emailInput.addEventListener("focusout", blankEmail);
+emailInput.addEventListener("focusin", resetEmailInput);
+
+//2. 공통: 이메일 input에서 focus out 할 때, 
+//이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보입니다
+
+const emailPattern = /^[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/i;
+
+function invalidEmail(event) {
+  if (!(event.target.value === "") && !(emailPattern.test(event.target.value))){
+    event.target.classList.add("input-error");
+    emailErrorMessage.textContent = "올바른 이메일 주소가 아닙니다.";
+  }
+}
+
+emailInput.addEventListener("focusout", invalidEmail);
+
+//3. 공통: 이메일 input에서 focus out 일 때
+//input 값이 test@codeit.com 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보입니다.
+
+function duplicateEmail(event) {
+  if (event.target.value === "test@codeit.com"){
+    event.target.classList.add("input-error");
+    emailErrorMessage.textContent = "이미 사용 중인 이메일입니다.";
+  }
+}
+
+emailInput.addEventListener("focusout", duplicateEmail);
+
+//4. 공통: 비밀번호 input에서 focus out 할 때
+//값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보입니다.
+
+const passwordInput = document.getElementById("password");
+const passwordErrorMessage = passwordInput.nextElementSibling;
+
+const passwordPattern = /^(?=.*[a-zA-Z])(?=.*\d).{8,}$/;
+
+function invalidPassword(event) {
+  if (!passwordPattern.test(event.target.value)){
+    event.target.classList.add("input-error");
+    passwordErrorMessage.textContent = "비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.";
+  } else {
+    event.target.classList.remove("input-error");
+  }
+}
+
+function resetPasswordInput(event) {
+  passwordErrorMessage.textContent = "";
+}
+
+passwordInput.addEventListener("focusout", invalidPassword);
+passwordInput.addEventListener("focusin", resetPasswordInput);
+
+//6. 공통: 비밀번호 input에서 focus out 할 때
+//값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지가 보입니다.
+
+function blankPassword(event) {
+  if (event.target.value === ""){
+    event.target.classList.add("input-error");
+    passwordErrorMessage.textContent = "비밀번호를 입력해주세요.";
+  }
+}
+
+passwordInput.addEventListener("focusout", blankPassword);

--- a/signup.js
+++ b/signup.js
@@ -98,7 +98,7 @@ function checkPassword(event) {
   }
 }
 
-checkPasswordInput.addEventListener("keyup", checkPassword);
+checkPasswordInput.addEventListener("focusout", checkPassword);
 
 //9. 10. 11. 회원가입 페이지
 //회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 에러 메세지로 알립니다.

--- a/signup.js
+++ b/signup.js
@@ -99,3 +99,17 @@ function checkPassword(event) {
 }
 
 checkPasswordInput.addEventListener("keyup", checkPassword);
+
+//9. 10. 회원가입 페이지
+//회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 에러 메세지로 알립니다.
+//이외의 유효한 회원가입 시도의 경우, “/folder”로 이동합니다.
+
+const signupButton = document.querySelector(".signup-button");
+
+function testSignup(event) {
+  if (!emailInput.classList.contains("input-error") && !passwordInput.classList.contains("input-error") && !checkPasswordInput.classList.contains("input-error")) {
+    signupButton.href = "/folder";
+  }
+}
+
+signupButton.addEventListener("click", testSignup);

--- a/signup.js
+++ b/signup.js
@@ -117,3 +117,25 @@ function testSignup(event) {
 
 signupButton.addEventListener("click", testSignup);
 document.addEventListener("keyup", testSignup);
+
+//12. 공통(심화): 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 합니다.
+//비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이도록 합니다.
+
+const passwordIcon =passwordInput.parentElement.lastElementChild;
+const checkPasswordIcon = checkPasswordInput.parentElement.lastElementChild;  //회원가입 페이지
+
+function showPassword(event) {
+  event.target.classList.toggle("eye-on");
+  if (event.target.classList.contains("eye-on")) {
+    event.target.parentElement.firstElementChild.type = "text";
+    event.target.src = "./images/eye-on.png";
+    event.target.alt="비밀번호 보이기 icon";
+  } else {
+    event.target.parentElement.firstElementChild.type = "password";
+    event.target.src = "./images/eye-off.png";
+    event.target.alt="비밀번호 가리기 icon";
+  }
+}
+
+passwordIcon.addEventListener("click", showPassword);
+checkPasswordIcon.addEventListener("click", showPassword);  //회원가입 페이지

--- a/signup.js
+++ b/signup.js
@@ -100,16 +100,20 @@ function checkPassword(event) {
 
 checkPasswordInput.addEventListener("keyup", checkPassword);
 
-//9. 10. 회원가입 페이지
+//9. 10. 11. 회원가입 페이지
 //회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 에러 메세지로 알립니다.
 //이외의 유효한 회원가입 시도의 경우, “/folder”로 이동합니다.
+//회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 됩니다.
 
 const signupButton = document.querySelector(".signup-button");
 
 function testSignup(event) {
-  if (!emailInput.classList.contains("input-error") && !passwordInput.classList.contains("input-error") && !checkPasswordInput.classList.contains("input-error")) {
-    signupButton.href = "/folder";
+  if ((event.target === signupButton) || (event.key === "Enter")){
+    if (!emailInput.classList.contains("input-error") && !passwordInput.classList.contains("input-error") && !checkPasswordInput.classList.contains("input-error")) {
+      window.location.href = "/folder";
+    }
   }
 }
 
 signupButton.addEventListener("click", testSignup);
+document.addEventListener("keyup", testSignup);

--- a/signup.js
+++ b/signup.js
@@ -81,3 +81,21 @@ function blankPassword(event) {
 }
 
 passwordInput.addEventListener("focusout", blankPassword);
+
+//8. 회원가입 페이지
+//비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보입니다.
+
+const checkPasswordInput = document.getElementById("check-password");
+const checkPasswordErrorMessage = checkPasswordInput.nextElementSibling;
+
+function checkPassword(event) {
+  if (passwordInput.value !== checkPasswordInput.value) {
+    event.target.classList.add("input-error");
+    checkPasswordErrorMessage.textContent = "비밀번호가 일치하지 않아요.";
+  } else {
+    event.target.classList.remove("input-error");
+    checkPasswordErrorMessage.textContent = "";
+  }
+}
+
+checkPasswordInput.addEventListener("keyup", checkPassword);

--- a/src/signin.css
+++ b/src/signin.css
@@ -110,12 +110,12 @@ input:focus {
   font-size: 1.4rem;
 }
 
-.social-logo {
+.social-logo-container {
   display: flex;
   gap: 1.6rem;
 }
 
-.social-logo img {
+.social-logo-container img {
   width: 4.2rem;
   height: 4.2rem;
 }

--- a/src/signin.css
+++ b/src/signin.css
@@ -94,7 +94,7 @@ input:focus {
   display: block;
   margin-top: 0.6rem;
   font-size: 1.4rem;
-  color: var(--linkbrary-red, #FF5B56);
+  color: var(--linkbrary-red);
 }
 
 .eye-icon {

--- a/src/signin.css
+++ b/src/signin.css
@@ -97,7 +97,7 @@ input:focus {
   color: var(--linkbrary-red, #FF5B56);
 }
 
-.eyeoff-icon {
+.eye-icon {
   position: absolute;
   top: 2.2rem;
   right: 1.8rem;

--- a/src/signin.css
+++ b/src/signin.css
@@ -86,6 +86,17 @@ input:focus {
   border: 1px solid var(--linkbrary-primary-color);
 }
 
+.input-error {
+  border-color: var(--linkbrary-red);
+}
+
+.error-massage {
+  display: block;
+  margin-top: 0.6rem;
+  font-size: 1.4rem;
+  color: var(--linkbrary-red, #FF5B56);
+}
+
 .eyeoff-icon {
   position: absolute;
   top: 2.2rem;

--- a/src/signup.css
+++ b/src/signup.css
@@ -110,12 +110,12 @@ input:focus {
   font-size: 1.4rem;
 }
 
-.social-logo {
+.social-logo-container {
   display: flex;
   gap: 1.6rem;
 }
 
-.social-logo img {
+.social-logo-container img {
   width: 4.2rem;
   height: 4.2rem;
 }

--- a/src/signup.css
+++ b/src/signup.css
@@ -94,7 +94,7 @@ input:focus {
   display: block;
   margin-top: 0.6rem;
   font-size: 1.4rem;
-  color: var(--linkbrary-red, #FF5B56);
+  color: var(--linkbrary-red);
 }
 
 .eye-icon {

--- a/src/signup.css
+++ b/src/signup.css
@@ -86,6 +86,17 @@ input:focus {
   border: 1px solid var(--linkbrary-primary-color);
 }
 
+.input-error {
+  border-color: var(--linkbrary-red);
+}
+
+.error-massage {
+  display: block;
+  margin-top: 0.6rem;
+  font-size: 1.4rem;
+  color: var(--linkbrary-red, #FF5B56);
+}
+
 .eyeon-icon {
   position: absolute;
   top: 2.2rem;

--- a/src/signup.css
+++ b/src/signup.css
@@ -97,7 +97,7 @@ input:focus {
   color: var(--linkbrary-red, #FF5B56);
 }
 
-.eyeon-icon {
+.eye-icon {
   position: absolute;
   top: 2.2rem;
   right: 1.8rem;


### PR DESCRIPTION
## 요구사항

### 기본

- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?

- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?

- [x] 이메일 input에서 focus out 일 때, input 값이 test@codeit.com 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?

- [x] 비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?

- [x] 비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?

- [x] 회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?

- [x] 이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?

- [x] 이메일: test@codeit.com, 비밀번호: codeit101 으로 로그인 시도할 경우, “/folder” 페이지로 이동하나요?

- [x] 비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지가 보이나요?

- [x] 이외의 로그인 시도의 경우 이메일, 비밀번호 input에 빨강색 테두리와 각각의 input아래에 “이메일을 확인해주세요.”, “비밀번호를 확인해주세요.” 빨강색 에러 메세지가 보이나요?

- [x] 회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?

- [x] 이메일, 비밀번호 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?

### 심화

- [x] 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?

- [x] 비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?

- [ ] 로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?

## 주요 변경사항

- 로그인, 회원가입 페이지 이벤트 구현

## 스크린샷

[사이트](https://linkbrary-project.netlify.app/signin)

## 멘토에게

- 코드를 효율적으로 짜고싶었는데 전혀 못했습니다
- input값을 바꿔가면서 테스트하긴 했는데 잘 구현이 되었는지 모르겠고
`event.target.classList.remove("input-error");
emailErrorMessage.textContent = "";`
초기화는 어느부분에 넣어야 할지 잘 모르겠습니다
- 이벤트리스너에서 event.target과 변수를 섞어서 사용했는데 어떻게 해야 좋을지 궁금합니다
- 모듈화는 시도했으나 잘 안되서 시간관계상 그냥 제출합니다..
