### PR TITLE
[정용준] Week4

### DIFF
--- a/auth/signin.html
+++ b/auth/signin.html
@@ -25,21 +25,20 @@
           </nav>
         </header>
         <div class="auth-inputs">
-          <div class="auth-input">
+          <div class="auth-input email">
             <label for="id"> 이메일 </label>
             <div data-state="normal" class="input-wrapper">
               <input id="id" name="id" placeholder="이메일을 입력해주세요." />
             </div>
             <small data-state="normal" class="input-message"></small>
           </div>
-          <div class="auth-input">
+          <div class="auth-input password">
             <label for="password"> 비밀번호 </label>
             <div data-state="normal" class="input-wrapper">
               <input
                 id="password"
                 name="password"
                 placeholder="비밀번호를 입력해주세요."
-                required
                 type="password"
               />
               <button
@@ -88,4 +87,5 @@
       </nav>
     </main>
   </body>
+  <script type="module" src="/src/auth/signin.js"></script>
 </html>

--- a/auth/signin.html
+++ b/auth/signin.html
@@ -27,19 +27,14 @@
         <div class="auth-inputs">
           <div class="auth-input">
             <label for="id"> 이메일 </label>
-            <div class="input-wrapper">
-              <input
-                id="id"
-                name="id"
-                type="email"
-                placeholder="이메일을 입력해주세요."
-                required
-              />
+            <div data-state="normal" class="input-wrapper">
+              <input id="id" name="id" placeholder="이메일을 입력해주세요." />
             </div>
+            <small data-state="normal" class="input-message"></small>
           </div>
           <div class="auth-input">
             <label for="password"> 비밀번호 </label>
-            <div class="input-wrapper">
+            <div data-state="normal" class="input-wrapper">
               <input
                 id="password"
                 name="password"
@@ -59,6 +54,7 @@
                 />
               </button>
             </div>
+            <small data-state="normal" class="input-message"></small>
           </div>
           <button type="submit" class="auth-submit">로그인</button>
         </div>

--- a/auth/signin.html
+++ b/auth/signin.html
@@ -43,7 +43,7 @@
               />
               <button
                 type="button"
-                class="icon eyetoggle"
+                class="icon password-toggle"
                 aria-label="패스워드 숨기기"
               >
                 <img

--- a/auth/signup.html
+++ b/auth/signup.html
@@ -51,7 +51,7 @@
                 aria-label="패스워드 보이기"
               >
                 <img
-                  src="https://res.cloudinary.com/divjslgco/image/upload/f_auto,q_auto/v1/codeit/icons/eye-on"
+                  src="https://res.cloudinary.com/divjslgco/image/upload/f_auto,q_auto/v1/codeit/icons/eye-off"
                   alt="패스워드 보이기"
                   aria-hidden
                 />
@@ -74,7 +74,7 @@
                 aria-label="패스워드 보이기"
               >
                 <img
-                  src="https://res.cloudinary.com/divjslgco/image/upload/f_auto,q_auto/v1/codeit/icons/eye-on"
+                  src="https://res.cloudinary.com/divjslgco/image/upload/f_auto,q_auto/v1/codeit/icons/eye-off"
                   alt="패스워드 보이기"
                   aria-hidden
                 />

--- a/auth/signup.html
+++ b/auth/signup.html
@@ -27,7 +27,7 @@
         <div class="auth-inputs">
           <div class="auth-input">
             <label for="email"> 이메일 </label>
-            <div class="input-wrapper">
+            <div data-state="normal" class="input-wrapper">
               <input
                 id="email"
                 name="email"
@@ -36,10 +36,11 @@
                 required
               />
             </div>
+            <small data-state="normal" class="input-message"></small>
           </div>
           <div class="auth-input">
             <label for="password"> 비밀번호 </label>
-            <div class="input-wrapper">
+            <div data-state="normal" class="input-wrapper">
               <input
                 id="password"
                 name="password"
@@ -59,10 +60,11 @@
                 />
               </button>
             </div>
+            <small data-state="normal" class="input-message"></small>
           </div>
           <div class="auth-input">
             <label for="password-confirm"> 비밀번호 확인 </label>
-            <div class="input-wrapper">
+            <div data-state="normal" class="input-wrapper">
               <input
                 id="password-confirm"
                 name="password-confirm"
@@ -82,6 +84,7 @@
                 />
               </button>
             </div>
+            <small data-state="normal" class="input-message"></small>
           </div>
           <button type="submit" class="auth-submit">회원가입</button>
         </div>

--- a/auth/signup.html
+++ b/auth/signup.html
@@ -9,7 +9,7 @@
   </head>
   <body class="auth-wrapper">
     <main class="auth-content">
-      <form class="auth-form signin">
+      <form class="auth-form signup">
         <header class="auth-form-header">
           <a href="/index.html" class="logo" aria-label="홈페이지로 이동">
             <h1 class="hidden">Linkbrary</h1>
@@ -25,27 +25,24 @@
           </nav>
         </header>
         <div class="auth-inputs">
-          <div class="auth-input">
+          <div class="auth-input email">
             <label for="email"> 이메일 </label>
             <div data-state="normal" class="input-wrapper">
               <input
                 id="email"
                 name="email"
-                type="email"
                 placeholder="이메일을 입력해주세요."
-                required
               />
             </div>
             <small data-state="normal" class="input-message"></small>
           </div>
-          <div class="auth-input">
+          <div class="auth-input password">
             <label for="password"> 비밀번호 </label>
             <div data-state="normal" class="input-wrapper">
               <input
                 id="password"
                 name="password"
                 placeholder="비밀번호를 입력해주세요."
-                required
                 type="password"
               />
               <button
@@ -62,14 +59,13 @@
             </div>
             <small data-state="normal" class="input-message"></small>
           </div>
-          <div class="auth-input">
+          <div class="auth-input password-confirm">
             <label for="password-confirm"> 비밀번호 확인 </label>
             <div data-state="normal" class="input-wrapper">
               <input
                 id="password-confirm"
                 name="password-confirm"
                 placeholder="비밀번호를 재입력해주세요."
-                required
                 type="password"
               />
               <button
@@ -115,4 +111,5 @@
       </nav>
     </main>
   </body>
+  <script type="module" src="/src/auth/signup.js"></script>
 </html>

--- a/auth/signup.html
+++ b/auth/signup.html
@@ -47,7 +47,7 @@
               />
               <button
                 type="button"
-                class="icon eyetoggle"
+                class="icon password-toggle"
                 aria-label="패스워드 보이기"
               >
                 <img
@@ -70,7 +70,7 @@
               />
               <button
                 type="button"
-                class="icon eyetoggle"
+                class="icon password-toggle"
                 aria-label="패스워드 보이기"
               >
                 <img

--- a/css/auth/index.css
+++ b/css/auth/index.css
@@ -72,44 +72,6 @@
   cursor: pointer;
 }
 
-.input-wrapper {
-  position: relative;
-  overflow: hidden;
-  border: 1px solid var(--color-gray-3);
-  border-radius: 0.8rem;
-  background-color: var(--color-white);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.input-wrapper > input {
-  padding: 1.8rem 1.5rem;
-  flex-grow: 1;
-  height: 100%;
-  border: 0;
-  background-color: inherit;
-}
-
-.input-message {
-  margin-top: 0.6rem;
-  display: none;
-  font-size: 1.4rem;
-}
-
-.input-wrapper:focus-within {
-  border: 1px solid var(--color-primary);
-}
-
-.input-wrapper[data-state="error"] {
-  border: 1px solid var(--color-red);
-}
-
-.input-message[data-state="error"] {
-  display: block;
-  color: var(--color-red);
-}
-
 .auth-input > .input-wrapper {
   margin-top: 1.2rem;
 }

--- a/css/auth/index.css
+++ b/css/auth/index.css
@@ -76,7 +76,7 @@
   margin-top: 1.2rem;
 }
 
-.icon.eyetoggle {
+.icon.password-toggle {
   padding: 0.8rem;
   margin-right: 0.7rem;
 
@@ -84,7 +84,7 @@
   align-items: center;
 }
 
-.eyetoggle > img {
+.password-toggle > img {
   width: 1.6rem;
   height: 1.6rem;
 }

--- a/css/auth/index.css
+++ b/css/auth/index.css
@@ -72,35 +72,46 @@
   cursor: pointer;
 }
 
-.auth-input > .input-wrapper {
-  margin-top: 1.2rem;
-  border: 1px solid var(--color-gray-3);
-  border-radius: 0.8rem;
-  background-color: var(--color-white);
-}
-
-.auth-input > .input-wrapper:focus-within {
-  border: 1px solid var(--color-primary);
-}
-
-.auth-input > .input-wrapper > input {
-  padding: 1.8rem 1.5rem;
-}
-
 .input-wrapper {
   position: relative;
   overflow: hidden;
-
+  border: 1px solid var(--color-gray-3);
+  border-radius: 0.8rem;
+  background-color: var(--color-white);
   display: flex;
   align-items: center;
   justify-content: space-between;
 }
 
 .input-wrapper > input {
+  padding: 1.8rem 1.5rem;
   flex-grow: 1;
   height: 100%;
   border: 0;
   background-color: inherit;
+}
+
+.input-message {
+  margin-top: 0.6rem;
+  display: none;
+  font-size: 1.4rem;
+}
+
+.input-wrapper:focus-within {
+  border: 1px solid var(--color-primary);
+}
+
+.input-wrapper[data-state="error"] {
+  border: 1px solid var(--color-red);
+}
+
+.input-message[data-state="error"] {
+  display: block;
+  color: var(--color-red);
+}
+
+.auth-input > .input-wrapper {
+  margin-top: 1.2rem;
 }
 
 .icon.eyetoggle {

--- a/css/globals.css
+++ b/css/globals.css
@@ -71,6 +71,43 @@
 }
 
 @layer components {
+  .input-wrapper {
+    position: relative;
+    overflow: hidden;
+    border: 1px solid var(--color-gray-3);
+    border-radius: 0.8rem;
+    background-color: var(--color-white);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .input-wrapper > input {
+    padding: 1.8rem 1.5rem;
+    flex-grow: 1;
+    height: 100%;
+    border: 0;
+    background-color: inherit;
+  }
+
+  .input-message {
+    margin-top: 0.6rem;
+    display: none;
+    font-size: 1.4rem;
+  }
+
+  .input-wrapper:focus-within {
+    border: 1px solid var(--color-primary);
+  }
+
+  .input-wrapper[data-state="error"] {
+    border: 1px solid var(--color-red);
+  }
+
+  .input-message[data-state="error"] {
+    display: block;
+    color: var(--color-red);
+  }
 }
 
 @layer utilities {

--- a/src/auth/signin.js
+++ b/src/auth/signin.js
@@ -1,0 +1,100 @@
+const InputMessage = {
+  ERROR_EMPTY_EMAIL: "이메일을 입력해주세요.",
+  ERROR_INVALID_EMAIL_FORMAT: "올바른 이메일 주소가 아닙니다.",
+  ERROR_DUPLICATE_EMAIL: "이미 사용 중인 이메일입니다.",
+  ERROR_EMPTY_PASSWORD: "비밀번호를 입력해주세요.",
+  ERROR_INVALID_PASSWORD_FORMAT:
+    "비밀번호는 영문,숫자 조합 8자 이상 입력해 주세요.",
+  ERROR_DIFFER_PASSWORD_CONFIRM: "비밀번호가 일치하지 않아요",
+  ERROR_NO_MATCHING_EMAIL: "이메일을 확인해 주세요.",
+  ERROR_NO_MATCHING_PASSWORD: "비밀번호를 확인해 주세요.",
+};
+
+const getChildElementsAsNode = (query) =>
+  Array.from(document.querySelector(query)?.childNodes).filter(
+    (node) => node.nodeType === Node.ELEMENT_NODE
+  );
+
+const signinForm = document.querySelector(".signin");
+const [_, emailInputEl, emailMessageEl] = getChildElementsAsNode(".email");
+const [__, passwordInputEl, passwordMessageEl] =
+  getChildElementsAsNode(".password");
+
+const showInputErrorMessage = (inputEl, message) => {
+  const messageEl = inputEl.parentElement.lastElementChild;
+  messageEl.textContent = message;
+  messageEl.dataset.state = "error";
+};
+
+const hideInputErrorMessage = (inputEl) => {
+  inputEl.parentElement.lastElementChild.dataset.state = "normal";
+};
+
+const validateEmail = (email) => {
+  if (email === "")
+    return { ok: false, message: InputMessage.ERROR_EMPTY_EMAIL };
+  return { ok: true, message: "" };
+};
+
+const validatePassword = (password) => {
+  if (password === "")
+    return { ok: false, message: InputMessage.ERROR_EMPTY_PASSWORD };
+  return { ok: true, message: "" };
+};
+
+const handleEmailFocusOut = (e) => {
+  const { ok, message } = validateEmail(e.target.value);
+  if (!ok) {
+    emailInputEl.dataset.state = "error";
+    showInputErrorMessage(emailInputEl, message);
+  } else {
+    emailInputEl.dataset.state = "normal";
+    hideInputErrorMessage(emailInputEl);
+  }
+};
+
+const handlePasswordFocusOut = (e) => {
+  const { ok, message } = validatePassword(e.target.value);
+  if (!ok) {
+    passwordInputEl.dataset.state = "error";
+    showInputErrorMessage(passwordInputEl, message);
+  } else {
+    passwordInputEl.dataset.state = "normal";
+    hideInputErrorMessage(passwordInputEl);
+  }
+};
+
+const handleSubmitSignin = (e) => {
+  e.preventDefault();
+  const [email, password] = Array.from(e.srcElement)
+    .filter((node) => node.nodeName === "INPUT")
+    .map((input) => input.value);
+  const { ok: emailOk, message: emailMessage } = validateEmail(email);
+  if (!emailOk) {
+    emailInputEl.dataset.state = "error";
+    showInputErrorMessage(emailInputEl, emailMessage);
+    return;
+  }
+  const { ok: passwordOk, message: passwordMessage } =
+    validatePassword(password);
+  if (!passwordOk) {
+    passwordInputEl.dataset.state = "error";
+    showInputErrorMessage(passwordInputEl, passwordMessage);
+    return;
+  }
+  if (email !== "test@codeit.com" || password !== "codeit101") {
+    emailInputEl.dataset.state = "error";
+    showInputErrorMessage(emailInputEl, InputMessage.ERROR_NO_MATCHING_EMAIL);
+    passwordInputEl.dataset.state = "error";
+    showInputErrorMessage(
+      passwordInputEl,
+      InputMessage.ERROR_NO_MATCHING_PASSWORD
+    );
+    return;
+  }
+  location.href = "/folder";
+};
+
+emailInputEl.addEventListener("focusout", handleEmailFocusOut);
+passwordInputEl.addEventListener("focusout", handlePasswordFocusOut);
+signinForm.addEventListener("submit", handleSubmitSignin);

--- a/src/auth/signin.js
+++ b/src/auth/signin.js
@@ -38,6 +38,7 @@ const validateEmail = (email) => {
 };
 
 const validatePassword = (password) => {
+  console.log("password: ", password);
   if (password === "")
     return { ok: false, message: InputMessage.ERROR_EMPTY_PASSWORD };
   return { ok: true, message: "" };
@@ -49,6 +50,15 @@ const togglePassword = (inputEl) => {
   } else {
     inputEl.type = "password";
   }
+};
+
+const togglePasswordIcon = (inputEl, buttonEl) => {
+  const isShown = inputEl.type === "password";
+  const baseUrl =
+    "https://res.cloudinary.com/divjslgco/image/upload/f_auto,q_auto/v1/codeit/icons/";
+  const iconEl = buttonEl.children[0];
+  iconEl.src = isShown ? `${baseUrl}/eye-off` : `${baseUrl}/eye-on`;
+  iconEl.alt = isShown ? "패스워드 숨기기" : "패스워드 보이기";
 };
 
 const handleEmailFocusOut = (e) => {
@@ -109,6 +119,7 @@ const handlePasswordToggle = (e) => {
     (el) => el.nodeName === "INPUT"
   );
   togglePassword(inputEl);
+  togglePasswordIcon(inputEl, e.currentTarget);
 };
 
 emailInputEl.addEventListener("focusout", handleEmailFocusOut);

--- a/src/auth/signin.js
+++ b/src/auth/signin.js
@@ -19,6 +19,7 @@ const signinForm = document.querySelector(".signin");
 const [_, emailInputEl, emailMessageEl] = getChildElementsAsNode(".email");
 const [__, passwordInputEl, passwordMessageEl] =
   getChildElementsAsNode(".password");
+const passwordToggleButtonEl = document.querySelector(".password-toggle");
 
 const showInputErrorMessage = (inputEl, message) => {
   const messageEl = inputEl.parentElement.lastElementChild;
@@ -40,6 +41,14 @@ const validatePassword = (password) => {
   if (password === "")
     return { ok: false, message: InputMessage.ERROR_EMPTY_PASSWORD };
   return { ok: true, message: "" };
+};
+
+const togglePassword = (inputEl) => {
+  if (inputEl.type === "password") {
+    inputEl.type = "text";
+  } else {
+    inputEl.type = "password";
+  }
 };
 
 const handleEmailFocusOut = (e) => {
@@ -95,6 +104,14 @@ const handleSubmitSignin = (e) => {
   location.href = "/folder";
 };
 
+const handlePasswordToggle = (e) => {
+  const [inputEl] = Array.from(e.currentTarget.parentElement.children).filter(
+    (el) => el.nodeName === "INPUT"
+  );
+  togglePassword(inputEl);
+};
+
 emailInputEl.addEventListener("focusout", handleEmailFocusOut);
 passwordInputEl.addEventListener("focusout", handlePasswordFocusOut);
 signinForm.addEventListener("submit", handleSubmitSignin);
+passwordToggleButtonEl.addEventListener("click", handlePasswordToggle);

--- a/src/auth/signin.js
+++ b/src/auth/signin.js
@@ -38,7 +38,6 @@ const validateEmail = (email) => {
 };
 
 const validatePassword = (password) => {
-  console.log("password: ", password);
   if (password === "")
     return { ok: false, message: InputMessage.ERROR_EMPTY_PASSWORD };
   return { ok: true, message: "" };
@@ -73,6 +72,7 @@ const handleEmailFocusOut = (e) => {
 };
 
 const handlePasswordFocusOut = (e) => {
+  if (e.target.nodeName !== "INPUT") return;
   const { ok, message } = validatePassword(e.target.value);
   if (!ok) {
     passwordInputEl.dataset.state = "error";

--- a/src/auth/signup.js
+++ b/src/auth/signup.js
@@ -21,6 +21,7 @@ const [__, passwordInputEl, passwordMessageEl] =
   getChildElementsAsNode(".password");
 const [___, passwordConfirmInputEl, passwordConfirmMessageEl] =
   getChildElementsAsNode(".password-confirm");
+const passwordToggleButtonEls = document.querySelectorAll(".password-toggle");
 
 const showInputErrorMessage = (inputEl, message) => {
   const messageEl = inputEl.parentElement.lastElementChild;
@@ -61,6 +62,14 @@ const validatePasswordConfirm = (passwordConfirm) => {
   if (passwordConfirm !== password)
     return { ok: false, message: InputMessage.ERROR_DIFFER_PASSWORD_CONFIRM };
   return { ok: true, message: "" };
+};
+
+const togglePassword = (inputEl) => {
+  if (inputEl.type === "password") {
+    inputEl.type = "text";
+  } else {
+    inputEl.type = "password";
+  }
 };
 
 const handleEmailFocusOut = (e) => {
@@ -124,6 +133,13 @@ const handleSubmitSignup = (e) => {
   location.href = "/folder";
 };
 
+const handlePasswordToggle = (e) => {
+  const [inputEl] = Array.from(e.currentTarget.parentElement.children).filter(
+    (el) => el.nodeName === "INPUT"
+  );
+  togglePassword(inputEl);
+};
+
 emailInputEl.addEventListener("focusout", handleEmailFocusOut);
 passwordInputEl.addEventListener("focusout", handlePasswordFocusOut);
 passwordConfirmInputEl.addEventListener(
@@ -131,3 +147,6 @@ passwordConfirmInputEl.addEventListener(
   handlePasswordConfirmFocusOut
 );
 signupForm.addEventListener("submit", handleSubmitSignup);
+passwordToggleButtonEls.forEach((el) =>
+  el.addEventListener("click", handlePasswordToggle)
+);

--- a/src/auth/signup.js
+++ b/src/auth/signup.js
@@ -1,0 +1,133 @@
+const InputMessage = {
+  ERROR_EMPTY_EMAIL: "이메일을 입력해주세요.",
+  ERROR_INVALID_EMAIL_FORMAT: "올바른 이메일 주소가 아닙니다.",
+  ERROR_DUPLICATE_EMAIL: "이미 사용 중인 이메일입니다.",
+  ERROR_EMPTY_PASSWORD: "비밀번호를 입력해주세요.",
+  ERROR_INVALID_PASSWORD_FORMAT:
+    "비밀번호는 영문,숫자 조합 8자 이상 입력해 주세요.",
+  ERROR_DIFFER_PASSWORD_CONFIRM: "비밀번호가 일치하지 않아요",
+  ERROR_NO_MATCHING_EMAIL: "이메일을 확인해 주세요.",
+  ERROR_NO_MATCHING_PASSWORD: "비밀번호를 확인해 주세요.",
+};
+
+const getChildElementsAsNode = (query) =>
+  Array.from(document.querySelector(query)?.childNodes).filter(
+    (node) => node.nodeType === Node.ELEMENT_NODE
+  );
+
+const signupForm = document.querySelector(".signup");
+const [_, emailInputEl, emailMessageEl] = getChildElementsAsNode(".email");
+const [__, passwordInputEl, passwordMessageEl] =
+  getChildElementsAsNode(".password");
+const [___, passwordConfirmInputEl, passwordConfirmMessageEl] =
+  getChildElementsAsNode(".password-confirm");
+
+const showInputErrorMessage = (inputEl, message) => {
+  const messageEl = inputEl.parentElement.lastElementChild;
+  messageEl.textContent = message;
+  messageEl.dataset.state = "error";
+};
+
+const hideInputErrorMessage = (inputEl) => {
+  inputEl.parentElement.lastElementChild.dataset.state = "normal";
+};
+
+const validateEmail = (email) => {
+  if (email === "")
+    return { ok: false, message: InputMessage.ERROR_EMPTY_EMAIL };
+  else if (
+    !/^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/.test(
+      email
+    )
+  )
+    return { ok: false, message: InputMessage.ERROR_INVALID_EMAIL_FORMAT };
+  else if (email === "test@codeit.com")
+    return { ok: false, message: InputMessage.ERROR_DUPLICATE_EMAIL };
+  return { ok: true, message: "" };
+};
+
+const validatePassword = (password) => {
+  if (
+    password.length < 8 ||
+    /^[A-Za-z]*$/.test(password) ||
+    /^\d*$/.test(password)
+  )
+    return { ok: false, message: InputMessage.ERROR_INVALID_PASSWORD_FORMAT };
+  return { ok: true, message: "" };
+};
+
+const validatePasswordConfirm = (passwordConfirm) => {
+  const password = passwordInputEl.children[0].value;
+  if (passwordConfirm !== password)
+    return { ok: false, message: InputMessage.ERROR_DIFFER_PASSWORD_CONFIRM };
+  return { ok: true, message: "" };
+};
+
+const handleEmailFocusOut = (e) => {
+  const { ok, message } = validateEmail(e.target.value);
+  if (!ok) {
+    emailInputEl.dataset.state = "error";
+    showInputErrorMessage(emailInputEl, message);
+  } else {
+    emailInputEl.dataset.state = "normal";
+    hideInputErrorMessage(emailInputEl);
+  }
+};
+
+const handlePasswordFocusOut = (e) => {
+  const { ok, message } = validatePassword(e.target.value);
+  if (!ok) {
+    passwordInputEl.dataset.state = "error";
+    showInputErrorMessage(passwordInputEl, message);
+  } else {
+    passwordInputEl.dataset.state = "normal";
+    hideInputErrorMessage(passwordInputEl);
+  }
+};
+
+const handlePasswordConfirmFocusOut = (e) => {
+  const { ok, message } = validatePasswordConfirm(e.target.value);
+  if (!ok) {
+    passwordConfirmInputEl.dataset.state = "error";
+    showInputErrorMessage(passwordConfirmInputEl, message);
+  } else {
+    passwordConfirmInputEl.dataset.state = "normal";
+    hideInputErrorMessage(passwordConfirmInputEl);
+  }
+};
+
+const handleSubmitSignup = (e) => {
+  e.preventDefault();
+  const [email, password, passwordConfirm] = Array.from(e.srcElement)
+    .filter((node) => node.nodeName === "INPUT")
+    .map((input) => input.value);
+  const { ok: emailOk, message: emailMessage } = validateEmail(email);
+  if (!emailOk) {
+    emailInputEl.dataset.state = "error";
+    showInputErrorMessage(emailInputEl, emailMessage);
+    return;
+  }
+  const { ok: passwordOk, message: passwordMessage } =
+    validatePassword(password);
+  if (!passwordOk) {
+    passwordInputEl.dataset.state = "error";
+    showInputErrorMessage(passwordInputEl, passwordMessage);
+    return;
+  }
+  const { ok: passwordConfirmOk, message: passwordConfirmMessage } =
+    validatePasswordConfirm(passwordConfirm);
+  if (!passwordConfirmOk) {
+    passwordConfirmInputEl.dataset.state = "error";
+    showInputErrorMessage(passwordConfirmInputEl, passwordConfirmMessage);
+    return;
+  }
+  location.href = "/folder";
+};
+
+emailInputEl.addEventListener("focusout", handleEmailFocusOut);
+passwordInputEl.addEventListener("focusout", handlePasswordFocusOut);
+passwordConfirmInputEl.addEventListener(
+  "focusout",
+  handlePasswordConfirmFocusOut
+);
+signupForm.addEventListener("submit", handleSubmitSignup);

--- a/src/auth/signup.js
+++ b/src/auth/signup.js
@@ -93,6 +93,7 @@ const handleEmailFocusOut = (e) => {
 };
 
 const handlePasswordFocusOut = (e) => {
+  if (e.target.nodeName !== "INPUT") return;
   const { ok, message } = validatePassword(e.target.value);
   if (!ok) {
     passwordInputEl.dataset.state = "error";
@@ -104,6 +105,7 @@ const handlePasswordFocusOut = (e) => {
 };
 
 const handlePasswordConfirmFocusOut = (e) => {
+  if (e.target.nodeName !== "INPUT") return;
   const { ok, message } = validatePasswordConfirm(e.target.value);
   if (!ok) {
     passwordConfirmInputEl.dataset.state = "error";

--- a/src/auth/signup.js
+++ b/src/auth/signup.js
@@ -72,6 +72,15 @@ const togglePassword = (inputEl) => {
   }
 };
 
+const togglePasswordIcon = (inputEl, buttonEl) => {
+  const isShown = inputEl.type === "password";
+  const baseUrl =
+    "https://res.cloudinary.com/divjslgco/image/upload/f_auto,q_auto/v1/codeit/icons/";
+  const iconEl = buttonEl.children[0];
+  iconEl.src = isShown ? `${baseUrl}/eye-off` : `${baseUrl}/eye-on`;
+  iconEl.alt = isShown ? "패스워드 숨기기" : "패스워드 보이기";
+};
+
 const handleEmailFocusOut = (e) => {
   const { ok, message } = validateEmail(e.target.value);
   if (!ok) {
@@ -138,6 +147,7 @@ const handlePasswordToggle = (e) => {
     (el) => el.nodeName === "INPUT"
   );
   togglePassword(inputEl);
+  togglePasswordIcon(inputEl, e.currentTarget);
 };
 
 emailInputEl.addEventListener("focusout", handleEmailFocusOut);


### PR DESCRIPTION
## 요구사항

### 기본

- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?


- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?


- [x] 이메일 input에서 focus out 일 때, input 값이 test@codeit.com 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?


- [x] 비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?


- [x] 비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?


- [x] 회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?


- [x] 이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?


- [x] 이메일: test@codeit.com, 비밀번호: codeit101 으로 로그인 시도할 경우, “/folder” 페이지로 이동하나요?


- [x] 비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지가 보이나요?


- [x] 이외의 로그인 시도의 경우 이메일, 비밀번호 input에 빨강색 테두리와 각각의 input아래에 “이메일을 확인해주세요.”, “비밀번호를 확인해주세요.” 빨강색 에러 메세지가 보이나요?


- [x] 회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?


- [x] 이메일, 비밀번호 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?

### 심화

- [x] 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?


- [x] 비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?


- [ ] 로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?

## 주요 변경사항

- 회원가입 유효성 검사 추가
- 로그인 유효성 검사 추가

## 스크린샷

![image](이미지url)

## 멘토에게

- 리팩터링이 매우 필요합니다.
- 심화 기능 구현 후 리팩터링 하겠습니다.
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
