### PR TITLE
[유미정] Week4

### DIFF
--- a/css/global_styles.css
+++ b/css/global_styles.css
@@ -1,7 +1,7 @@
 :root {
   --main-color: #6d6afe;
+  --alert-color: #ff5b56;
   --white-text-color: #f5f5f5;
-  --alert-text-color: #ff5b56;
   --main-background-color: #f0f6ff;
   --black-background-color: #111322;
   --white-background-color: #fff;

--- a/css/global_styles.css
+++ b/css/global_styles.css
@@ -1,11 +1,12 @@
 :root {
-  --primary: #6d6afe;
-  --red: #ff5b56;
-  --black: #111322;
-  --white: #fff;
-  --gray-100: #373740;
-  --gray-60: #9fa6b2;
-  --gray-20: #ccd5e3;
-  --gray-10: #e7effb;
-  --bg: #f0f6ff;
+  --main-color: #6d6afe;
+  --white-text-color: #f5f5f5;
+  --alert-text-color: #ff5b56;
+  --main-background-color: #f0f6ff;
+  --black-background-color: #111322;
+  --white-background-color: #fff;
+  --gray-darker-color: #373740;
+  --gray-dark-color: #9fa6b2;
+  --gray-light-color: #ccd5e3;
+  --gray-lighter-color: #e7effb;
 }

--- a/css/index.css
+++ b/css/index.css
@@ -16,7 +16,7 @@ header {
   padding: 0 20rem;
   margin: 0 auto;
 }
-.logo img {
+.logo > img {
   width: 133px;
 }
 .login-button {
@@ -52,7 +52,7 @@ header {
   text-align: center;
   word-break: keep-all;
 }
-.top-section-title span {
+.top-section-title > span {
   background: linear-gradient(91deg, var(--main-color) 17.28%, #ff9f9f 74.98%);
   background-clip: text;
   -webkit-background-clip: text;
@@ -107,25 +107,25 @@ header {
   letter-spacing: -0.03rem;
   grid-area: title;
 }
-.section-title span {
+.section-title > span {
   background-clip: text;
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
 }
-#card-section1 .section-title span {
+#card-section1 > .section-title > span {
   background-image: linear-gradient(96deg, #fe8a8a 1.72%, #a4ceff 74.97%);
 }
-#card-section2 .section-title span {
+#card-section2 > .section-title > span {
   background-image: linear-gradient(277deg, #6fbaff 59.22%, #ffd88b 93.66%);
 }
-#card-section3 .section-title span {
+#card-section3 > .section-title > span {
   background-image: linear-gradient(
     99deg,
     #6d7ccd 19.76%,
     rgba(82, 136, 133, 0.22) 52.69%
   );
 }
-#card-section4 .section-title span {
+#card-section4 > .section-title > span {
   background-image: linear-gradient(271deg, #fe578f -9.84%, #68e8f9 107.18%);
 }
 .section-text {
@@ -163,7 +163,7 @@ footer {
   gap: 3rem;
   font-size: 1.8rem;
 }
-.policy-faq-wrap a {
+.policy-faq-wrap > a {
   color: #cfcfcf;
 }
 .sns-wrap {
@@ -209,7 +209,7 @@ footer {
   .header-wrap {
     height: 6.3rem;
   }
-  .logo img {
+  .logo > img {
     width: auto;
     height: 16px;
   }

--- a/css/index.css
+++ b/css/index.css
@@ -4,7 +4,7 @@
 header {
   position: sticky;
   top: 0;
-  background: var(--bg);
+  background: var(--main-background-color);
 }
 .header-wrap {
   display: flex;
@@ -26,18 +26,18 @@ header {
   border-radius: 0.8rem;
   background-image: linear-gradient(
     91deg,
-    var(--primary) 0.12%,
+    var(--main-color) 0.12%,
     #6ae3fe 101.84%
   );
   font-size: 1.8rem;
   font-weight: 600;
-  color: #f5f5f5;
+  color: var(--white-text-color);
   text-align: center;
 }
 /* 2. main */
 .top-section {
   padding-top: 7rem;
-  background: var(--bg);
+  background: var(--main-background-color);
 }
 .top-section-wrap {
   display: flex;
@@ -53,7 +53,7 @@ header {
   word-break: keep-all;
 }
 .top-section-title span {
-  background: linear-gradient(91deg, var(--primary) 17.28%, #ff9f9f 74.98%);
+  background: linear-gradient(91deg, var(--main-color) 17.28%, #ff9f9f 74.98%);
   background-clip: text;
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
@@ -63,10 +63,10 @@ header {
   width: 35rem;
   padding: 1.6rem 2rem;
   border-radius: 0.8rem;
-  background: linear-gradient(91deg, var(--primary) 0.12%, #6ae3fe 101.84%);
+  background: linear-gradient(91deg, var(--main-color) 0.12%, #6ae3fe 101.84%);
   font-size: 1.8rem;
   font-weight: 600;
-  color: #f5f5f5;
+  color: var(--white-text-color);
   text-align: center;
 }
 .top-section-img {
@@ -142,7 +142,7 @@ header {
 }
 /* 3. footer */
 footer {
-  background-color: var(--black);
+  background-color: var(--black-background-color);
 }
 .footer-wrap {
   display: flex;

--- a/css/sign.css
+++ b/css/sign.css
@@ -42,16 +42,16 @@ main {
   flex-direction: column;
   width: 100%;
 }
-.input-wrap {
+.label-input-wrap {
   display: flex;
   gap: 1.2rem;
   flex-direction: column;
 }
-.input-wrap > label {
+.label-input-wrap > label {
   font-size: 1.4rem;
   font-weight: 400;
 }
-.input-wrap input {
+.label-input-wrap input {
   width: 100%;
   padding: 1.8rem 4rem 1.8rem 1.5rem;
   border: 1px solid var(--gray-light-color);
@@ -61,13 +61,13 @@ main {
   line-height: 2.4rem;
   color: var(--gray-darker-color);
 }
-.input-wrap input:focus {
+.label-input-wrap input:focus {
   border: 1px solid var(--main-color);
 }
-.input-hidden-wrap {
+.input-wrap {
   position: relative;
 }
-.input-hidden-wrap > img {
+.input-wrap > img {
   position: absolute;
   top: 50%;
   right: 1.5rem;

--- a/css/sign.css
+++ b/css/sign.css
@@ -27,16 +27,16 @@ main {
 .logo img {
   height: 3.8rem;
 }
-.logo-wrap p {
+.logo-wrap > p {
   font-size: 1.6rem;
   line-height: 2.4rem;
 }
-.logo-wrap p a {
+.logo-wrap > p > a {
   border-bottom: 1px solid var(--main-color);
   font-weight: 600;
   color: var(--main-color);
 }
-.sign-wrap form {
+.sign-wrap > form {
   display: flex;
   gap: 2.4rem;
   flex-direction: column;
@@ -47,7 +47,7 @@ main {
   gap: 1.2rem;
   flex-direction: column;
 }
-.input-wrap label {
+.input-wrap > label {
   font-size: 1.4rem;
   font-weight: 400;
 }
@@ -67,7 +67,7 @@ main {
 .input-hidden-wrap {
   position: relative;
 }
-.input-hidden-wrap img {
+.input-hidden-wrap > img {
   position: absolute;
   top: 50%;
   right: 1.5rem;
@@ -99,7 +99,7 @@ main {
   gap: 1.6rem;
   align-items: center;
 }
-.sns-logo-wrap a {
+.sns-logo-wrap > a {
   display: flex;
   align-items: center;
 }

--- a/css/sign.css
+++ b/css/sign.css
@@ -1,7 +1,7 @@
 @import url("global_styles.css");
 
 body {
-  background-color: var(--bg);
+  background-color: var(--main-background-color);
 }
 main {
   display: flex;
@@ -32,9 +32,9 @@ main {
   line-height: 2.4rem;
 }
 .logo-wrap p a {
-  border-bottom: 1px solid var(--primary);
+  border-bottom: 1px solid var(--main-color);
   font-weight: 600;
-  color: var(--primary);
+  color: var(--main-color);
 }
 .sign-wrap form {
   display: flex;
@@ -54,15 +54,15 @@ main {
 .input-wrap input {
   width: 100%;
   padding: 1.8rem 4rem 1.8rem 1.5rem;
-  border: 1px solid var(--gray-20);
+  border: 1px solid var(--gray-light-color);
   border-radius: 0.8rem;
   outline: none;
   font-size: 1.6rem;
   line-height: 2.4rem;
-  color: var(--gray-100);
+  color: var(--gray-darker-color);
 }
 .input-wrap input:focus {
-  border: 1px solid var(--primary);
+  border: 1px solid var(--main-color);
 }
 .input-hidden-wrap {
   position: relative;
@@ -78,9 +78,9 @@ main {
   padding: 1.6rem 2rem;
   margin-top: 0.6rem;
   border-radius: 0.8rem;
-  background: linear-gradient(91deg, var(--primary) 0.12%, #6ae3fe 101.84%);
+  background: linear-gradient(91deg, var(--main-color) 0.12%, #6ae3fe 101.84%);
   font-size: 1.8rem;
-  color: #f5f5f5;
+  color: var(--white-text-color);
 }
 .sns-sign-wrap {
   display: flex;
@@ -88,11 +88,11 @@ main {
   justify-content: space-between;
   width: 100%;
   padding: 1.2rem 2.4rem;
-  border: 1px solid var(--gray-20);
+  border: 1px solid var(--gray-light-color);
   border-radius: 0.8rem;
-  background-color: var(--gray-10);
+  background-color: var(--gray-lighter-color);
   font-size: 1.4rem;
-  color: var(--gray-100);
+  color: var(--gray-darker-color);
 }
 .sns-logo-wrap {
   display: flex;

--- a/css/sign.css
+++ b/css/sign.css
@@ -46,6 +46,7 @@ main {
   display: flex;
   gap: 1.2rem;
   flex-direction: column;
+  position: relative;
 }
 .label-input-wrap > label {
   font-size: 1.4rem;
@@ -64,6 +65,9 @@ main {
 .label-input-wrap input:focus {
   border: 1px solid var(--main-color);
 }
+.label-input-wrap input.alert {
+  border: 1px solid var(--alert-color);
+}
 .input-wrap {
   position: relative;
 }
@@ -73,6 +77,13 @@ main {
   right: 1.5rem;
   cursor: pointer;
   transform: translateY(-50%);
+}
+.input-alert {
+  position: absolute;
+  bottom: -0.6rem;
+  font-size: 1.4rem;
+  color: var(--alert-color);
+  transform: translateY(100%);
 }
 .submit-button {
   padding: 1.6rem 2rem;

--- a/folder.html
+++ b/folder.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Document</title>
+</head>
+<body>
+  
+</body>
+</html>

--- a/js/sign_module.js
+++ b/js/sign_module.js
@@ -1,0 +1,22 @@
+export function toggleVisiblePassword() {
+  const visiblePasswordIcon = document.querySelectorAll(".input-wrap > img");
+
+  visiblePasswordIcon.forEach((iconEle) => {
+    iconEle.addEventListener("click", () => {
+      const currentType = iconEle.previousElementSibling.getAttribute("type");
+      const inputType = currentType === "password" ? "text" : "password";
+      const imgSrc =
+        currentType === "password"
+          ? "./img/icon/eye_on_icon.svg"
+          : "./img/icon/eye_off_icon.svg";
+      const imgAlt =
+        currentType === "password"
+          ? "현재 비밀번호가 보이는 상태 아이콘"
+          : "현재 비밀번호가 보이지 않는 상태 아이콘";
+
+      iconEle.previousElementSibling.setAttribute("type", inputType);
+      iconEle.setAttribute("src", imgSrc);
+      iconEle.setAttribute("alt", imgAlt);
+    });
+  });
+}

--- a/js/signin.js
+++ b/js/signin.js
@@ -1,3 +1,5 @@
+import { toggleVisiblePassword } from "./sign_module.js";
+
 const emailInput = document.querySelector("#email");
 const passwordInput = document.querySelector("#password");
 const form = document.querySelector("form");
@@ -50,30 +52,11 @@ form.addEventListener("submit", (e) => {
     emailInput.value === "test@codeit.com" &&
     passwordInput.value === "codeit101"
   ) {
-    window.location.href = "./folder";
+    window.location.href = "./folder.html";
   } else {
     focusOutAlert(emailInput, inputErrMessage.emailNotRegistered);
     focusOutAlert(passwordInput, inputErrMessage.passwordNotRegistered);
   }
 });
 
-const visiblePasswordIcon = document.querySelectorAll(".input-wrap > img");
-
-visiblePasswordIcon.forEach((iconEle) => {
-  iconEle.addEventListener("click", () => {
-    const currentType = iconEle.previousElementSibling.getAttribute("type");
-    const inputType = currentType === "password" ? "text" : "password";
-    const imgSrc =
-      currentType === "password"
-        ? "./img/icon/eye_on_icon.svg"
-        : "./img/icon/eye_off_icon.svg";
-    const imgAlt =
-      currentType === "password"
-        ? "현재 비밀번호가 보이는 상태 아이콘"
-        : "현재 비밀번호가 보이지 않는 상태 아이콘";
-
-    iconEle.previousElementSibling.setAttribute("type", inputType);
-    iconEle.setAttribute("src", imgSrc);
-    iconEle.setAttribute("alt", imgAlt);
-  });
-});
+toggleVisiblePassword();

--- a/js/signin.js
+++ b/js/signin.js
@@ -1,0 +1,58 @@
+const emailInput = document.querySelector("#email");
+const passwordInput = document.querySelector("#password");
+const form = document.querySelector("form");
+
+const inputErrMessage = {
+  emailNull: "이메일을 입력해주세요.",
+  emailNotRegistered: "이메일을 확인해주세요.",
+  passwordNull: "비밀번호를 입력해주세요.",
+  passwordNotRegistered: "비밀번호를 확인해주세요.",
+};
+
+function focusOutAlert(ele, message) {
+  ele.classList.add("alert");
+  ele.parentElement.nextElementSibling.textContent = message;
+  ele.dataset.boolean = 0;
+}
+
+function emailInputFocusOut(ele) {
+  ele.classList.remove("alert");
+  emailInput.parentElement.nextElementSibling.textContent = "";
+  emailInput.dataset.boolean = 1;
+  if (ele.value === "") {
+    focusOutAlert(ele, inputErrMessage.emailNull);
+  }
+}
+
+function passwordInputFocusOut(ele) {
+  ele.classList.remove("alert");
+  passwordInput.parentElement.nextElementSibling.textContent = "";
+  passwordInput.dataset.boolean = 1;
+  if (ele.value === "") {
+    focusOutAlert(ele, inputErrMessage.passwordNull);
+  }
+}
+
+emailInput.addEventListener("focusout", (e) => {
+  emailInputFocusOut(e.target);
+});
+
+passwordInput.addEventListener("focusout", (e) => {
+  passwordInputFocusOut(e.target);
+});
+
+form.addEventListener("submit", (e) => {
+  e.preventDefault();
+  emailInputFocusOut(emailInput);
+  passwordInputFocusOut(passwordInput);
+
+  if (
+    emailInput.value === "test@codeit.com" &&
+    passwordInput.value === "codeit101"
+  ) {
+    window.location.href = "./folder";
+  } else {
+    focusOutAlert(emailInput, inputErrMessage.emailNotRegistered);
+    focusOutAlert(passwordInput, inputErrMessage.passwordNotRegistered);
+  }
+});

--- a/js/signin.js
+++ b/js/signin.js
@@ -56,3 +56,24 @@ form.addEventListener("submit", (e) => {
     focusOutAlert(passwordInput, inputErrMessage.passwordNotRegistered);
   }
 });
+
+const visiblePasswordIcon = document.querySelectorAll(".input-wrap > img");
+
+visiblePasswordIcon.forEach((iconEle) => {
+  iconEle.addEventListener("click", () => {
+    const currentType = iconEle.previousElementSibling.getAttribute("type");
+    const inputType = currentType === "password" ? "text" : "password";
+    const imgSrc =
+      currentType === "password"
+        ? "./img/icon/eye_on_icon.svg"
+        : "./img/icon/eye_off_icon.svg";
+    const imgAlt =
+      currentType === "password"
+        ? "현재 비밀번호가 보이는 상태 아이콘"
+        : "현재 비밀번호가 보이지 않는 상태 아이콘";
+
+    iconEle.previousElementSibling.setAttribute("type", inputType);
+    iconEle.setAttribute("src", imgSrc);
+    iconEle.setAttribute("alt", imgAlt);
+  });
+});

--- a/js/signup.js
+++ b/js/signup.js
@@ -18,11 +18,13 @@ const inputErrMessage = {
 };
 
 function focusOutAlert(ele, message) {
+  ele.classList.add("alert");
   ele.parentElement.nextElementSibling.textContent = message;
   ele.dataset.boolean = 0;
 }
 
 function emailInputFocusOut(ele) {
+  ele.classList.remove("alert");
   emailInput.parentElement.nextElementSibling.textContent = "";
   emailInput.dataset.boolean = 1;
   if (ele.value === "") {
@@ -35,6 +37,7 @@ function emailInputFocusOut(ele) {
 }
 
 function passwordInputFocusOut(ele) {
+  ele.classList.remove("alert");
   passwordInput.parentElement.nextElementSibling.textContent = "";
   passwordInput.dataset.boolean = 1;
   if (ele.value === "") {
@@ -45,6 +48,7 @@ function passwordInputFocusOut(ele) {
 }
 
 function passwordCheckInputFocusOut(ele) {
+  ele.classList.remove("alert");
   passwordCheckInput.parentElement.nextElementSibling.textContent = "";
   passwordCheckInput.dataset.boolean = 1;
   if (ele.value !== passwordInput.value) {

--- a/js/signup.js
+++ b/js/signup.js
@@ -1,9 +1,11 @@
+import { toggleVisiblePassword } from "./sign_module.js";
+
 const emailInput = document.querySelector("#email");
 const passwordInput = document.querySelector("#password");
 const passwordCheckInput = document.querySelector("#password-check");
+const form = document.querySelector("form");
 const emailRegex = new RegExp("[a-z0-9]+@[a-z]+.[a-z]{2,3}");
 const passwordRegex = new RegExp(/^(?=.*[a-zA-Z])(?=.*[0-9]).{8,}$/);
-const form = document.querySelector("form");
 
 const inputErrMessage = {
   emailNull: "이메일을 입력해주세요.",
@@ -76,27 +78,8 @@ form.addEventListener("submit", (e) => {
     Boolean(Number(passwordInput.dataset.boolean)) &&
     Boolean(Number(passwordCheckInput.dataset.boolean))
   ) {
-    window.location.href = "./folder";
+    window.location.href = "./folder.html";
   }
 });
 
-const visiblePasswordIcon = document.querySelectorAll(".input-wrap > img");
-
-visiblePasswordIcon.forEach((iconEle) => {
-  iconEle.addEventListener("click", () => {
-    const currentType = iconEle.previousElementSibling.getAttribute("type");
-    const inputType = currentType === "password" ? "text" : "password";
-    const imgSrc =
-      currentType === "password"
-        ? "./img/icon/eye_on_icon.svg"
-        : "./img/icon/eye_off_icon.svg";
-    const imgAlt =
-      currentType === "password"
-        ? "현재 비밀번호가 보이는 상태 아이콘"
-        : "현재 비밀번호가 보이지 않는 상태 아이콘";
-
-    iconEle.previousElementSibling.setAttribute("type", inputType);
-    iconEle.setAttribute("src", imgSrc);
-    iconEle.setAttribute("alt", imgAlt);
-  });
-});
+toggleVisiblePassword();

--- a/js/signup.js
+++ b/js/signup.js
@@ -1,16 +1,13 @@
 const emailInput = document.querySelector("#email");
 const passwordInput = document.querySelector("#password");
 const passwordCheckInput = document.querySelector("#password-check");
-const inputAlert = document.querySelectorAll(".input-alert");
 const emailRegex = new RegExp("[a-z0-9]+@[a-z]+.[a-z]{2,3}");
 const passwordRegex = new RegExp(/^(?=.*[a-zA-Z])(?=.*[0-9]).{8,}$/);
-const submitButton = document.querySelector(".submit-button");
 const form = document.querySelector("form");
 
 const inputErrMessage = {
   emailNull: "이메일을 입력해주세요.",
   emailInvalid: "올바른 이메일 주소가 아닙니다.",
-  emailNotRegistered: "이메일을 확인해주세요.",
   emailExisting: "이미 사용 중인 이메일입니다.",
   passwordInvalid: "비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.",
   passwordNull: "비밀번호를 입력해주세요.",

--- a/js/signup.js
+++ b/js/signup.js
@@ -79,3 +79,24 @@ form.addEventListener("submit", (e) => {
     window.location.href = "./folder";
   }
 });
+
+const visiblePasswordIcon = document.querySelectorAll(".input-wrap > img");
+
+visiblePasswordIcon.forEach((iconEle) => {
+  iconEle.addEventListener("click", () => {
+    const currentType = iconEle.previousElementSibling.getAttribute("type");
+    const inputType = currentType === "password" ? "text" : "password";
+    const imgSrc =
+      currentType === "password"
+        ? "./img/icon/eye_on_icon.svg"
+        : "./img/icon/eye_off_icon.svg";
+    const imgAlt =
+      currentType === "password"
+        ? "현재 비밀번호가 보이는 상태 아이콘"
+        : "현재 비밀번호가 보이지 않는 상태 아이콘";
+
+    iconEle.previousElementSibling.setAttribute("type", inputType);
+    iconEle.setAttribute("src", imgSrc);
+    iconEle.setAttribute("alt", imgAlt);
+  });
+});

--- a/js/signup.js
+++ b/js/signup.js
@@ -1,0 +1,80 @@
+const emailInput = document.querySelector("#email");
+const passwordInput = document.querySelector("#password");
+const passwordCheckInput = document.querySelector("#password-check");
+const inputAlert = document.querySelectorAll(".input-alert");
+const emailRegex = new RegExp("[a-z0-9]+@[a-z]+.[a-z]{2,3}");
+const passwordRegex = new RegExp(/^(?=.*[a-zA-Z])(?=.*[0-9]).{8,}$/);
+const submitButton = document.querySelector(".submit-button");
+const form = document.querySelector("form");
+
+const inputErrMessage = {
+  emailNull: "이메일을 입력해주세요.",
+  emailInvalid: "올바른 이메일 주소가 아닙니다.",
+  emailNotRegistered: "이메일을 확인해주세요.",
+  emailExisting: "이미 사용 중인 이메일입니다.",
+  passwordInvalid: "비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.",
+  passwordNull: "비밀번호를 입력해주세요.",
+  passwordNotMatch: "비밀번호가 일치하지 않아요.",
+};
+
+function focusOutAlert(ele, message) {
+  ele.parentElement.nextElementSibling.textContent = message;
+  ele.dataset.boolean = 0;
+}
+
+function emailInputFocusOut(ele) {
+  emailInput.parentElement.nextElementSibling.textContent = "";
+  emailInput.dataset.boolean = 1;
+  if (ele.value === "") {
+    focusOutAlert(ele, inputErrMessage.emailNull);
+  } else if (!emailRegex.test(ele.value)) {
+    focusOutAlert(ele, inputErrMessage.emailInvalid);
+  } else if (ele.value === "test@codeit.com") {
+    focusOutAlert(ele, inputErrMessage.emailExisting);
+  }
+}
+
+function passwordInputFocusOut(ele) {
+  passwordInput.parentElement.nextElementSibling.textContent = "";
+  passwordInput.dataset.boolean = 1;
+  if (ele.value === "") {
+    focusOutAlert(ele, inputErrMessage.passwordNull);
+  } else if (!passwordRegex.test(ele.value)) {
+    focusOutAlert(ele, inputErrMessage.passwordInvalid);
+  }
+}
+
+function passwordCheckInputFocusOut(ele) {
+  passwordCheckInput.parentElement.nextElementSibling.textContent = "";
+  passwordCheckInput.dataset.boolean = 1;
+  if (ele.value !== passwordInput.value) {
+    focusOutAlert(ele, inputErrMessage.passwordNotMatch);
+  }
+}
+
+emailInput.addEventListener("focusout", (e) => {
+  emailInputFocusOut(e.target);
+});
+
+passwordInput.addEventListener("focusout", (e) => {
+  passwordInputFocusOut(e.target);
+});
+
+passwordCheckInput.addEventListener("focusout", (e) => {
+  passwordCheckInputFocusOut(e.target);
+});
+
+form.addEventListener("submit", (e) => {
+  e.preventDefault();
+  emailInputFocusOut(emailInput);
+  passwordInputFocusOut(passwordInput);
+  passwordCheckInputFocusOut(passwordCheckInput);
+
+  if (
+    Boolean(Number(emailInput.dataset.boolean)) &&
+    Boolean(Number(passwordInput.dataset.boolean)) &&
+    Boolean(Number(passwordCheckInput.dataset.boolean))
+  ) {
+    window.location.href = "./folder";
+  }
+});

--- a/signin.html
+++ b/signin.html
@@ -27,7 +27,7 @@
               <input type="password" id="password" />
               <img
                 src="./img/icon/eye_off_icon.svg"
-                alt="비밀번호 안보이는 상태 아이콘"
+                alt="현재 비밀번호가 보이지 않는 상태 아이콘"
               />
             </div>
           </div>

--- a/signin.html
+++ b/signin.html
@@ -6,7 +6,7 @@
     <title>로그인</title>
     <link rel="stylesheet" href="./css/reset.css" />
     <link rel="stylesheet" href="./css/sign.css" />
-    <script defer src="./js/signin.js"></script>
+    <script defer type="module" src="./js/signin.js"></script>
   </head>
   <body>
     <main>

--- a/signin.html
+++ b/signin.html
@@ -6,6 +6,7 @@
     <title>로그인</title>
     <link rel="stylesheet" href="./css/reset.css" />
     <link rel="stylesheet" href="./css/sign.css" />
+    <!-- <script defer src="./js/signup.js"></script> -->
   </head>
   <body>
     <main>
@@ -17,19 +18,23 @@
           <p>회원이 아니신가요? <a href="signup.html">회원 가입하기</a></p>
         </div>
         <form>
-          <div class="input-wrap">
+          <div class="label-input-wrap">
             <label for="email">이메일</label>
-            <input type="email" id="email" />
+            <div class="input-wrap">
+              <input type="email" id="email" />
+            </div>
+            <span class="input-alert"></span>
           </div>
-          <div class="input-wrap">
+          <div class="label-input-wrap">
             <label for="password">비밀번호</label>
-            <div class="input-hidden-wrap">
+            <div class="input-wrap">
               <input type="password" id="password" />
               <img
                 src="./img/icon/eye_off_icon.svg"
                 alt="현재 비밀번호가 보이지 않는 상태 아이콘"
               />
             </div>
+            <span class="input-alert"></span>
           </div>
           <button class="submit-button">로그인</button>
         </form>

--- a/signin.html
+++ b/signin.html
@@ -6,7 +6,7 @@
     <title>로그인</title>
     <link rel="stylesheet" href="./css/reset.css" />
     <link rel="stylesheet" href="./css/sign.css" />
-    <!-- <script defer src="./js/signup.js"></script> -->
+    <script defer src="./js/signin.js"></script>
   </head>
   <body>
     <main>

--- a/signup.html
+++ b/signup.html
@@ -27,7 +27,7 @@
               <input type="password" id="password" />
               <img
                 src="./img/icon/eye_on_icon.svg"
-                alt="비밀번호 보이는 상태 아이콘"
+                alt="현재 비밀번호가 보이는 상태 아이콘"
               />
             </div>
           </div>
@@ -37,7 +37,7 @@
               <input type="password" id="password-check" />
               <img
                 src="./img/icon/eye_on_icon.svg"
-                alt="비밀번호 보이는 상태 아이콘"
+                alt="현재 비밀번호가 보이는 상태 아이콘"
               />
             </div>
           </div>

--- a/signup.html
+++ b/signup.html
@@ -6,7 +6,7 @@
     <title>회원가입</title>
     <link rel="stylesheet" href="./css/reset.css" />
     <link rel="stylesheet" href="./css/sign.css" />
-    <script defer src="./js/signup.js"></script>
+    <script defer type="module" src="./js/signup.js"></script>
   </head>
   <body>
     <main>

--- a/signup.html
+++ b/signup.html
@@ -30,7 +30,7 @@
             <div class="input-wrap">
               <input type="password" id="password" />
               <img
-                src="./img/icon/eye_on_icon.svg"
+                src="./img/icon/eye_off_icon.svg"
                 alt="현재 비밀번호가 보이는 상태 아이콘"
               />
             </div>
@@ -41,7 +41,7 @@
             <div class="input-wrap">
               <input type="password" id="password-check" />
               <img
-                src="./img/icon/eye_on_icon.svg"
+                src="./img/icon/eye_off_icon.svg"
                 alt="현재 비밀번호가 보이는 상태 아이콘"
               />
             </div>

--- a/signup.html
+++ b/signup.html
@@ -6,6 +6,7 @@
     <title>회원가입</title>
     <link rel="stylesheet" href="./css/reset.css" />
     <link rel="stylesheet" href="./css/sign.css" />
+    <script defer src="./js/signup.js"></script>
   </head>
   <body>
     <main>
@@ -17,29 +18,34 @@
           <p>이미 회원이신가요? <a href="signin.html">로그인 하기</a></p>
         </div>
         <form>
-          <div class="input-wrap">
+          <div class="label-input-wrap">
             <label for="email">이메일</label>
-            <input type="email" id="email" />
+            <div class="input-wrap">
+              <input type="email" id="email" />
+            </div>
+            <span class="input-alert"></span>
           </div>
-          <div class="input-wrap">
+          <div class="label-input-wrap">
             <label for="password">비밀번호</label>
-            <div class="input-hidden-wrap">
+            <div class="input-wrap">
               <input type="password" id="password" />
               <img
                 src="./img/icon/eye_on_icon.svg"
                 alt="현재 비밀번호가 보이는 상태 아이콘"
               />
             </div>
+            <span class="input-alert"></span>
           </div>
-          <div class="input-wrap">
+          <div class="label-input-wrap">
             <label for="password-check">비밀번호 확인</label>
-            <div class="input-hidden-wrap">
+            <div class="input-wrap">
               <input type="password" id="password-check" />
               <img
                 src="./img/icon/eye_on_icon.svg"
                 alt="현재 비밀번호가 보이는 상태 아이콘"
               />
             </div>
+            <span class="input-alert"></span>
           </div>
           <button class="submit-button">회원가입</button>
         </form>


### PR DESCRIPTION
## 요구사항

### 기본

- [x] [기본]이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]이메일 input에서 focus out 일 때, input 값이 test@codeit.com 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?
- [x] [기본]이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?
- [x] [기본]이메일: test@codeit.com, 비밀번호: codeit101 으로 로그인 시도할 경우, “/folder” 페이지로 이동하나요?
- [x] [기본]비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지가 보이나요?
- [x] [기본]이외의 로그인 시도의 경우 이메일, 비밀번호 input에 빨강색 테두리와 각각의 input아래에 “이메일을 확인해주세요.”, “비밀번호를 확인해주세요.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?
- [x] [기본]이메일, 비밀번호 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?

### 심화

- [x] [심화]눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?
- [x] [심화]비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?
- [x] [심화]로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?

## 주요 변경사항

- 로그인, 회원가입 페이지 유효성 검사 기능 구현
- 공통된 코드 모듈화

## 스크린샷

![image](https://github.com/codeit-bootcamp-frontend/2-Weekly-Mission/assets/96277798/e8d0d7f4-7ca5-42fb-8ba3-32dfde70cd3b)

## 멘토에게

- 모듈화의 범위를 잘 모르겠습니다. 저는 완전히 같은 코드만 모듈화를 했는데 공통적인 코드가 있는 부분이 있거든요. 근데 그 코드가 공통적이지 않은 코드랑 같이 묶여있어서 따로 뺄 수가 없어 모듈화를 안 했어요. 이렇게 해도 될까요?
