### PR TITLE
[week4] 김윤미

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "endOfLine": "lf",
+  "tabWidth": 2,
+  "useTabs": false
+}

--- a/folder.html
+++ b/folder.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Linkbrary / Folder</title>
+</head>
+<body>
+  
+</body>
+</html>

--- a/script/signup.js
+++ b/script/signup.js
@@ -1,0 +1,156 @@
+import { TEST_USER, NEW_USER } from './utils.js'
+
+const errorMessage = {
+  email: {
+    unfilled: '이메일을 입력해주세요.',
+    invalid: '올바른 이메일 주소가 아닙니다.',
+    existed: '이미 사용 중인 이메일입니다.',
+    confirm: '이메일 확인해주세요.',
+  },
+  password: {
+    unfilled: '비밀번호를 입력해주세요.',
+    invalid: '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.',
+    inequal: '비밀번호가 일치하지 않아요.',
+    confirm: '비밀번호를 확인해주세요.',
+  },
+}
+
+/* 이메일 유효성 확인 */ 
+let isEmailValid = false
+let emailValue = ''
+const emailInput = document.querySelector('input#useremail')
+const emailErrorMessage = document.querySelector('.text-error#error-email')
+
+emailInput.addEventListener('focusout', (event) => {
+  const target = event.target
+  const EMAIL_REGEX = /^[a-zA-Z0-9._+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9.]+$/
+
+  if (EMAIL_REGEX.test(target.value)) {
+    // 정규식 조건 만족 O
+    target.parentNode.classList.remove('error')
+    emailErrorMessage.textContent = ''
+    isEmailValid = true
+    emailValue = target.value
+
+    if (target.value === TEST_USER.email) {
+      // 중복
+      target.parentNode.classList.add('error')
+      emailErrorMessage.textContent = errorMessage.email.existed
+    }
+  } else {
+    // 정규식 조건 만족 X
+    target.parentNode.classList.add('error')
+    emailErrorMessage.textContent = errorMessage.email.invalid
+
+    if (target.value === '') {
+      // 미입력
+      emailErrorMessage.textContent = errorMessage.email.unfilled
+    }
+  }
+})
+/* 비밀번호 유효성 확인 */
+let isPasswordValid = false
+let passwordValue = ''
+const passwordInput = document.querySelector('input#password')
+const passwordErrorMessage = document.querySelector(
+  '.text-error#error-password'
+)
+
+passwordInput.addEventListener('focusout', (event) => {
+  const target = event.target
+  const PASSWORD_REGEX = /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,25}$/
+
+  if (PASSWORD_REGEX.test(target.value)) {
+    // 정규식 조건 만족 O
+    target.parentNode.parentNode.classList.remove('error')
+    passwordErrorMessage.textContent = ''
+    isPasswordValid = true
+    NEW_USER.password = target.value
+    passwordValue = target.value
+  } else {
+    // 정규식 조건 만족 X
+    target.parentNode.parentNode.classList.add('error')
+    passwordErrorMessage.textContent = errorMessage.password.invalid
+    isPasswordValid = false
+    NEW_USER.password = null
+
+    if (target.value === '') {
+      // 미입력
+      target.parentNode.parentNode.classList.add('error')
+      passwordErrorMessage.textContent = errorMessage.password.unfilled
+    }
+  }
+})
+
+/* 비밀번호 재입력 값 일치 확인 */ 
+let isConfirmPasswordValid = false
+let confirmPasswordValue = ''
+const confirmPasswordInput = document.querySelector('input#password-confirm')
+const confirmPasswordErrorMessage = document.querySelector(
+  '.text-error#error-password-confirm'
+)
+
+confirmPasswordInput.addEventListener('focusout', (event) => {
+  const target = event.target
+  confirmPasswordValue = target.value
+
+  if (target.value === '') {
+    // 미입력
+    target.parentNode.parentNode.classList.add('error')
+    confirmPasswordErrorMessage.textContent = errorMessage.password.unfilled
+  } else if (passwordValue === confirmPasswordValue) {
+    // 비밀번호 재입력 일치 O
+    if (isPasswordValid) {
+      target.parentNode.parentNode.classList.remove('error')
+      confirmPasswordErrorMessage.textContent = ''
+      isConfirmPasswordValid = true
+    }
+  } else {
+    // 비밀번호 재입력 일치 X
+    target.parentNode.parentNode.classList.add('error')
+    confirmPasswordErrorMessage.textContent = errorMessage.password.inequal
+  }
+})
+
+/* 회원가입 성공 */ 
+const signupForm = document.querySelector('.sign-form')
+
+signupForm.addEventListener('submit', (event) => {
+  event.preventDefault()
+
+  if (isEmailValid && isPasswordValid && isConfirmPasswordValid) {
+    // 모든 정규식 조건 만족 O
+    location.href = '/folder.html'
+  }
+  if (!isEmailValid) {
+    emailErrorMessage.textContent = errorMessage.email.confirm
+  }
+  if (!isPasswordValid || isConfirmPasswordValid) {
+    passwordErrorMessage.textContent = errorMessage.password.confirm
+    confirmPasswordErrorMessage.textContent = errorMessage.password.confirm
+  }
+})
+
+/* 비밀번호 보기/숨기기 */
+const passwordToggleButton = document.querySelectorAll('.button-eye')
+
+function togglePassword(event) {
+  const target = event.target
+
+  // MEMO : console.log(target.previousElementSibling) 이렇게 선택하는게 안전한 방식일까? 나중에 형제 요소가 바뀔 수도 있는데...정확하게 형제 요소의 input 태그인 요소를 선택하려면 어떻게 해야 할까...
+
+  if (target.classList.contains('hide')) {
+    target.classList.remove('hide')
+    target.setAttribute('aria-label', '비밀번호 숨기기')
+    target.previousElementSibling.setAttribute('type', 'text')
+  } else {
+    event.target.classList.add('hide')
+    target.setAttribute('aria-label', '비밀번호 보기')
+    target.previousElementSibling.setAttribute('type', 'password')
+  }
+}
+passwordToggleButton.forEach((button) => {
+  button.addEventListener('click', togglePassword)
+})
+
+// MEMO : Refactor 에러 메시지 함수 만들어 보기

--- a/script/utils.js
+++ b/script/utils.js
@@ -1,0 +1,6 @@
+export const TEST_USER = {
+  email: "test@codeit.com",
+  password: "codeit101",
+}
+
+export const NEW_USER = {}

--- a/signin.html
+++ b/signin.html
@@ -21,29 +21,31 @@
     </header>
 
     <div class="sign-body">
-       <form class="sign-form">
-          <div class="input-container">
-            <div class="input-row">
-              <label for="useremail">이메일</label>
-              <input id="useremail" type="email" name="useremail" placeholder="codeit@codeit.com" />
-            </div>
-            <div class="input-row">
-              <label for="password">비밀번호</label>
-              <div class="input-wrap">
-                <input id="password" type="password" name="password" />
-                <!-- MEMO: .hide 클래스 활성시 aria-label의 텍스트 '비밀번호 숨기기' 변경 -->
-                <button class="button-show" aria-label="비밀번호 보기"></button>
-              </div>
-            </div>
+      <form class="sign-form">
+        <div class="input-container">
+          <div class="input-row">
+            <label for="useremail">이메일</label>
+            <input id="useremail" type="email" name="useremail" />
+            <p id="error-email" class="text-error"></p>
           </div>
-          <button type="submit" class="button-primary">로그인</button>
-        </form>
+          <div class="input-row">
+            <label for="password">비밀번호</label>
+            <div class="input-wrap">
+              <input id="password" type="password" name="password" />
+              <!-- MEMO: .hide 클래스 활성시 aria-label의 텍스트 '비밀번호 숨기기' 변경 -->
+              <button class="button-eye hide" type="button" aria-label="비밀번호 보기"></button>
+            </div>
+            <p id="error-password" class="text-error"></p>
+          </div>
+        </div>
+        <button class="button-primary" type="submit">로그인</button>
+      </form>
     </div>
 
     <footer class="sign-footer">
       <label>소셜 로그인</label>
       <div class="social-login">
-         <a href="https://www.google.com/">
+        <a href="https://www.google.com/">
           <img class="image" src="images/sign/icon_google.png" alt="구글" />
         </a>
         <a href="https://www.kakaocorp.com/page/">

--- a/signup.html
+++ b/signup.html
@@ -63,5 +63,6 @@
       </div>
     </footer>
   </div>
+  <script type="module" src="/script/signup.js"></script>
 </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -25,33 +25,36 @@
         <div class="input-container">
           <div class="input-row">
             <label for="useremail">이메일</label>
-            <input id="useremail" type="email" name="useremail" placeholder="codeit@codeit.com" />
+            <input id="useremail" type="email" name="useremail"/>
+            <p id="error-email" class="text-error">이메일을 입력해주세요.</p>
           </div>
           <div class="input-row">
             <label for="password">비밀번호</label>
             <div class="input-wrap">
               <input id="password" type="password" name="password" />
               <!-- MEMO: .hide 클래스 활성시 aria-label의 텍스트 '비밀번호 숨기기' 변경 -->
-              <button class="button-show" aria-label="비밀번호 보기"></button>
+              <button class="button-eye hide" type="button" aria-label="비밀번호 보기"></button>
             </div>
+            <p id="error-password" class="text-error"></p>
           </div>
           <div class="input-row">
-            <label for="password-repeat">비밀번호 확인</label>
+            <label for="password-confirm">비밀번호 확인</label>
             <div class="input-wrap">
-              <input id="password-repeat" type="password" name="password-repeat" />
+              <input id="password-confirm" type="password" name="password-confirm" />
               <!-- MEMO: .hide 클래스 활성시 aria-label의 텍스트 '비밀번호 숨기기' 변경 -->
-              <button class="button-show" aria-label="비밀번호 보기"></button>
+              <button class="button-eye hide" type="button" aria-label="비밀번호 보기"></button>
             </div>
+            <p id="error-password-confirm" class="text-error"></p>
           </div>
         </div>
-        <button type="submit" class="button-primary">회원가입</button>
+        <button class="button-primary" type="submit">회원가입</button>
       </form>
     </div>
 
     <footer class="sign-footer">
       <label>다른 방식으로 가입하기</label>
       <div class="social-login">
-          <a href="https://www.google.com/">
+        <a href="https://www.google.com/">
           <img class="image" src="images/sign/icon_google.png" alt="구글" />
         </a>
         <a href="https://www.kakaocorp.com/page/">

--- a/styles/sign.css
+++ b/styles/sign.css
@@ -123,10 +123,10 @@ body {
 .button-eye {
   position: absolute;
   top: 50%;
-  right: 1.5rem;
+  right: 0.3rem;
   transform: translateY(-50%);
-  width: 1.6rem;
-  height: 1.6rem;
+  width: 4rem;
+  height: 4rem;
   background: url('/images/sign/icon_eye_on.png') no-repeat center/ 1.6rem 1.6rem;
   cursor: pointer;
 }

--- a/styles/sign.css
+++ b/styles/sign.css
@@ -66,7 +66,7 @@ body {
 }
 
 .sign-form input#password,
-.sign-form input#password-repeat {
+.sign-form input#password-confirm {
   padding-right: 4.6rem;
 }
 
@@ -108,11 +108,19 @@ body {
   height: 4.2rem;
 }
 
+.input-row.error input {
+  border-color: var(--red-color);
+}
+
+.input-row.error .text-error {
+  display: block;
+}
+
 .input-wrap {
   position: relative;
 }
 
-.button-show {
+.button-eye {
   position: absolute;
   top: 50%;
   right: 1.5rem;
@@ -123,8 +131,15 @@ body {
   cursor: pointer;
 }
 
-.button-show.hide {
+.button-eye.hide {
     background: url('/images/sign/icon_eye_off.png') no-repeat center/ 1.6rem 1.6rem;
+}
+
+.text-error {
+  display: none;
+  margin-top: 0.6rem;
+  font-size: 1.4rem;
+  color: var(—red-color);
 }
 
 @media screen and (max-width: 768px) {

--- a/styles/sign.css
+++ b/styles/sign.css
@@ -130,7 +130,7 @@ body {
 @media screen and (max-width: 768px) {
   .sign {
     width: 100%;
-    margin: 12rem auto 0;
+    margin: 12rem auto;
     padding: 0 3.2rem;
   }
 

--- a/styles/sign.css
+++ b/styles/sign.css
@@ -132,14 +132,14 @@ body {
 }
 
 .button-eye.hide {
-    background: url('/images/sign/icon_eye_off.png') no-repeat center/ 1.6rem 1.6rem;
+  background: url('/images/sign/icon_eye_off.png') no-repeat center/ 1.6rem 1.6rem;
 }
 
 .text-error {
   display: none;
   margin-top: 0.6rem;
   font-size: 1.4rem;
-  color: var(—red-color);
+  color: var(--red-color);
 }
 
 @media screen and (max-width: 768px) {


### PR DESCRIPTION
## 요구사항

### 기본

- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?
- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?
- [x] 이메일 input에서 focus out 일 때, input 값이 test@codeit.com 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?
- [x] 비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?
- [x] 비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?
- [x] 회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?
- [x] 이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?
- [ ] 이메일: test@codeit.com, 비밀번호: codeit101 으로 로그인 시도할 경우, “/folder” 페이지로 이동하나요?
- [x] 비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지가 보이나요?
- [ ] 이외의 로그인 시도의 경우 이메일, 비밀번호 input에 빨강색 테두리와 각각의 input아래에 “이메일을 확인해주세요.”, “비밀번호를 확인해주세요.” 빨강색 에러 메세지가 보이나요?
- [ ] 회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?
- [x] 이메일, 비밀번호 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?


### 심화
- [x] 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?
- [x] 비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?
- [ ] 로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?


## 주요 변경사항

- 회원가입, 로그인, 이메일, 비밀번호 유효성 검사 기능 구현

## 스크린샷

https://github.com/codeit-bootcamp-frontend/2-Weekly-Mission/assets/97681668/994f43b1-d6c9-4896-a974-43b6bd37cb8d


## 멘토에게

- 동작하긴 하는데 이렇게 하는게 맞는건지 모르겠어요. 중복되는 코드가 많은데 어떻게 줄일 수 있을지 고민 되어요.
- 에러 메세지 태그를 자바스크립트에서 생성하는게 더 나은 방식인가요?
- togglePwShow(event) 이 함수에서 console.log(event.target)이 안찍히는데 원인을 모르겠어요.
- 비밀번호 중복 체크와 입력 내용 전체 유효성 체크는 구현 못했어요. 다시 차근차근 해볼게요.
- '이메일, 비밀번호 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?' 이 요구 사항은 어떤 의미인지 모르겠어요. css 파일을 모듈화하는 것일까요?
- 이메일 input에 처음에 이메일 형식이 맞지 않는 값을 넣으면 에레 메세지가 제대로 동작하는데, 다시 유효한 이메일을 입력해도 에러 메세지가 사라지지 않고 남아 있어요. 어떤 부분이 잘못 되었을까요.
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
