### PR TITLE
[이해빈] Week5

### DIFF
--- a/constant/constant.js
+++ b/constant/constant.js
@@ -1,2 +1,3 @@
 export const TEST_EMAIL = 'test@codeit.com';
 export const TEST_PASSWORD = 'codeit101';
+export const API_URL = 'https://bootcamp-api.codeit.kr/api';

--- a/constant/constant.js
+++ b/constant/constant.js
@@ -1,0 +1,2 @@
+export const TEST_EMAIL = 'test@codeit.com';
+export const TEST_PASSWORD = 'codeit101';

--- a/js/check.js
+++ b/js/check.js
@@ -20,7 +20,7 @@ export const checkEmpty = (inputElement) => {
 }
 
 export const checkEmail = (inputElement) => {
-  if(inputElement.value === '') return;
+  if(inputElement.value === '') return false;
   const emailValue = inputElement.value.trim();
   const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/;
   if (emailRegex.test(emailValue)) {

--- a/js/check.js
+++ b/js/check.js
@@ -42,3 +42,11 @@ export const checkPassword = (inputElement) => {
     return false;
   }
 }
+
+export const checkAccessToken = () => {
+  const accessToken = localStorage.getItem('accessToken');
+
+  if (accessToken) {
+    window.location.href = './folder.html';
+  }
+}

--- a/js/check.js
+++ b/js/check.js
@@ -5,16 +5,14 @@ export const checkEmpty = (inputElement) => {
   if(inputElement.value === '') {
     if(inputElement.id === 'email'){
       showError(inputElement, '이메일을 입력해주세요.');
-      return false;
     }
     if(inputElement.id === 'password') {
       showError(inputElement, '비밀번호를 입력해주세요.');
-      return false;
     }
     if(inputElement.id === 'password-check') {
       showError(inputElement, '비밀번호를 입력해주세요.');
-      return false;
     }
+    return false;
   }
   return true;
 }

--- a/js/check.js
+++ b/js/check.js
@@ -1,47 +1,44 @@
+import deleteError from "./deleteError.js";
 import showError from "./showError.js";
 
-export const checkEmpty = (tag) => {
-  if(tag.value === '') {
-    if(tag.id === 'email'){
-      showError(tag, '이메일을 입력해주세요.');
+export const checkEmpty = (inputElement) => {
+  if(inputElement.value === '') {
+    if(inputElement.id === 'email'){
+      showError(inputElement, '이메일을 입력해주세요.');
       return false;
     }
-    if(tag.id === 'password') {
-      showError(tag, '비밀번호를 입력해주세요.');
+    if(inputElement.id === 'password') {
+      showError(inputElement, '비밀번호를 입력해주세요.');
       return false;
     }
-    if(tag.id === 'password-check') {
-      showError(tag, '비밀번호를 입력해주세요.');
+    if(inputElement.id === 'password-check') {
+      showError(inputElement, '비밀번호를 입력해주세요.');
       return false;
     }
   }
   return true;
 }
 
-export const checkEmail = (tag) => {
-  if(tag.value === '') return;
-  const emailValue = tag.value.trim();
+export const checkEmail = (inputElement) => {
+  if(inputElement.value === '') return;
+  const emailValue = inputElement.value.trim();
   const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/;
   if (emailRegex.test(emailValue)) {
-    if(tag.parentNode.lastChild.className ==='error-message') {
-      tag.parentNode.removeChild(tag.parentNode.lastChild);
-      tag.classList.remove('input--error')
-      return true;
-    }
-    else return true;
+    deleteError(inputElement);
+    return true;
   }
   else {
-    showError(tag, '올바른 이메일 주소가 아닙니다.');
+    showError(inputElement, '올바른 이메일 주소가 아닙니다.');
     return false;
   }
 }
 
-export const checkPassword = (tag) => {
+export const checkPassword = (inputElement) => {
   const passwordRegex = /^(?=.*[A-Za-z])(?=.*\d).{8,}$/;
-  if (passwordRegex.test(tag.value)) return true;
+  if (passwordRegex.test(inputElement.value)) return true;
   else {
-    if(tag.value === '') return false;
-    showError(tag, '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.');
+    if(inputElement.value === '') return false;
+    showError(inputElement, '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.');
     return false;
   }
 }

--- a/js/deleteError.js
+++ b/js/deleteError.js
@@ -1,10 +1,8 @@
-const deleteError = (tag) => {
-  tag.classList.remove('input--error');
-  const parent = tag.parentNode;
-  const lastNode = tag.parentNode.lastChild;
-  if(lastNode.className === 'error-message'){
-    parent.removeChild(lastNode);
-  }
+const deleteError = (inputElement) => {
+  inputElement.classList.remove('input--error');
+  const parentElement = inputElement.parentNode;
+  const errorMessageElement = parentElement.querySelector('.error-message');
+  if(errorMessageElement) errorMessageElement.remove();
 }
 
 export default deleteError;

--- a/js/showError.js
+++ b/js/showError.js
@@ -1,15 +1,15 @@
 import makeDOM from "./makeDOM.js";
 
-const showError = (tag, message) => {
-  if(tag.parentNode.lastChild.className === 'error-message'){
-    tag.parentNode.lastChild.innerText = message;
+const showError = (inputElement, message) => {
+  if(inputElement.parentNode.lastChild.className === 'error-message'){
+    inputElement.parentNode.lastChild.innerText = message;
   } else {
     const errorMessage = makeDOM('p', {
       className: `error-message`,
       innerText: message
     });
-    tag.parentNode.appendChild(errorMessage);
-    tag.classList.add('input--error');
+    inputElement.parentNode.appendChild(errorMessage);
+    inputElement.classList.add('input--error');
   }
 };
 

--- a/js/signin.js
+++ b/js/signin.js
@@ -1,4 +1,4 @@
-import { TEST_EMAIL, TEST_PASSWORD } from "../constant/constant.js";
+import { API_URL } from "../constant/constant.js";
 import { checkEmail, checkEmpty } from "./check.js";
 import deleteError from "./deleteError.js";
 import showError from "./showError.js";
@@ -25,20 +25,40 @@ const togglePasswordVisibilityEvent = (e) => {
   if(e.target.classList.contains('eye')) togglePasswordVisibility(e.target);
 }
 
-const testSignIn = (e) => {
-  e.preventDefault();
-  if(e.target === document.querySelector('.signin--btn')){
-    const emailInput = document.querySelector('#email');
-    const passwordInput = document.querySelector('#password');
-    
-    if(emailInput.value === TEST_EMAIL && passwordInput.value === TEST_PASSWORD){
+const checkSignIn = async (emailInput, passwordInput) => {
+  try {
+    const response = await fetch(`${API_URL}/sign-in`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        email: emailInput.value, 
+        password: passwordInput.value
+      })
+    });
+    if(response.ok) {
       window.location.href = './folder.html';
     } else {
       showError(emailInput, '이메일/비밀번호를 확인해주세요');
       showError(passwordInput, '이메일/비밀번호를 확인해주세요');
     }
+  } catch (error) {
+    alert(error);
   }
 };
+
+const testSignIn = (e) => {
+  e.preventDefault();
+  if(e.target === document.querySelector('.signin--btn')){
+    const emailInput = document.querySelector('#email');
+    const passwordInput = document.querySelector('#password');
+
+    checkSignIn(emailInput, passwordInput);
+  }
+};
+
+
 
 emailInput.addEventListener('focusout', checkEmptyEvent);
 passwordInput.addEventListener('focusout', checkEmptyEvent);

--- a/js/signin.js
+++ b/js/signin.js
@@ -1,5 +1,5 @@
 import { API_URL } from "../constant/constant.js";
-import { checkEmail, checkEmpty } from "./check.js";
+import { checkAccessToken, checkEmail, checkEmpty } from "./check.js";
 import deleteError from "./deleteError.js";
 import showError from "./showError.js";
 import togglePasswordVisibility from "./togglePasswordVisibility.js";
@@ -39,6 +39,8 @@ const checkSignIn = async (emailInput, passwordInput) => {
     });
     if(response.ok) {
       window.location.href = './folder.html';
+      const { data } = await response.json();
+      localStorage.setItem('accessToken', data.accessToken);
     } else {
       showError(emailInput, '이메일/비밀번호를 확인해주세요');
       showError(passwordInput, '이메일/비밀번호를 확인해주세요');
@@ -68,3 +70,4 @@ emailInput.addEventListener('input', checkEmailEvent);
 emailInput.addEventListener('blur', checkEmailEvent);
 signInBtn.addEventListener('click', testSignIn);
 document.querySelector('.eye').addEventListener('click', togglePasswordVisibilityEvent);
+document.addEventListener('DOMContentLoaded', checkAccessToken);

--- a/js/signin.js
+++ b/js/signin.js
@@ -1,26 +1,28 @@
+import { TEST_EMAIL, TEST_PASSWORD } from "../constant/constant.js";
 import { checkEmail, checkEmpty } from "./check.js";
 import deleteError from "./deleteError.js";
 import showError from "./showError.js";
-import showPassword from "./showPassword.js";
+import togglePasswordVisibility from "./togglePasswordVisibility.js";
 
 const emailInput = document.querySelector('#email');
+const passwordInput = document.querySelector('#password');
 const signInBtn = document.querySelector('.signin--btn');
-const inputList = Array.from(document.querySelectorAll('input'));
+
 
 const checkEmptyEvent = (e) => {
-  if(inputList.includes(e.target)) checkEmpty(e.target);
+  if(e.target.id === 'email' || e.target.id === 'password') checkEmpty(e.target);
 }
 
 const deleteErrorEvent = (e) => {
-  if(inputList.includes(e.target)) deleteError(e.target);
+  if(e.target.id === 'email' || e.target.id === 'password') deleteError(e.target);
 }
 
 const checkEmailEvent = (e) => {
-  if(e.target === document.querySelector('#email')) checkEmail(e.target);
+  if(e.target === emailInput) checkEmail(e.target);
 }
 
-const showPasswordEvent = (e) => {
-  if(e.target.classList.contains('eye')) showPassword(e.target);
+const togglePasswordVisibilityEvent = (e) => {
+  if(e.target.classList.contains('eye')) togglePasswordVisibility(e.target);
 }
 
 const testSignIn = (e) => {
@@ -29,21 +31,20 @@ const testSignIn = (e) => {
     const emailInput = document.querySelector('#email');
     const passwordInput = document.querySelector('#password');
     
-    if(emailInput.value !== 'test@codeit.com') {
-      showError(emailInput, '이메일을 확인해주세요');
-    }
-    if(passwordInput.value !== 'codeit101') {
-      showError(passwordInput, '비밀번호를 확인해주세요');
-    }
-    if(emailInput.value === 'test@codeit.com' && passwordInput.value === 'codeit101'){
+    if(emailInput.value === TEST_EMAIL && passwordInput.value === TEST_PASSWORD){
       window.location.href = './folder.html';
+    } else {
+      showError(emailInput, '이메일/비밀번호를 확인해주세요');
+      showError(passwordInput, '이메일/비밀번호를 확인해주세요');
     }
   }
 };
 
-inputList.forEach((element) => {element.addEventListener('focusout', checkEmptyEvent)});
-inputList.forEach((element) => {element.addEventListener('focusin', deleteErrorEvent)});
+emailInput.addEventListener('focusout', checkEmptyEvent);
+passwordInput.addEventListener('focusout', checkEmptyEvent);
+emailInput.addEventListener('focusin', deleteErrorEvent);
+passwordInput.addEventListener('focusin', deleteErrorEvent);
 emailInput.addEventListener('input', checkEmailEvent);
 emailInput.addEventListener('blur', checkEmailEvent);
 signInBtn.addEventListener('click', testSignIn);
-document.body.addEventListener('click', showPasswordEvent);
+document.querySelector('.eye').addEventListener('click', togglePasswordVisibilityEvent);

--- a/js/signin.js
+++ b/js/signin.js
@@ -6,7 +6,6 @@ import togglePasswordVisibility from "./togglePasswordVisibility.js";
 
 const emailInput = document.querySelector('#email');
 const passwordInput = document.querySelector('#password');
-const signInBtn = document.querySelector('.signin--btn');
 
 
 const checkEmptyEvent = (e) => {
@@ -50,14 +49,16 @@ const checkSignIn = async (emailInput, passwordInput) => {
   }
 };
 
-const testSignIn = (e) => {
-  e.preventDefault();
-  if(e.target === document.querySelector('.signin--btn')){
-    const emailInput = document.querySelector('#email');
-    const passwordInput = document.querySelector('#password');
+const testSignIn = () => {
+  const emailInput = document.querySelector('#email');
+  const passwordInput = document.querySelector('#password');
 
-    checkSignIn(emailInput, passwordInput);
+  if(emailInput.value === '' || passwordInput.value === ''){
+    checkEmpty(emailInput);
+    checkEmpty(passwordInput);
+    return;
   }
+  checkSignIn(emailInput, passwordInput);
 };
 
 
@@ -68,6 +69,9 @@ emailInput.addEventListener('focusin', deleteErrorEvent);
 passwordInput.addEventListener('focusin', deleteErrorEvent);
 emailInput.addEventListener('input', checkEmailEvent);
 emailInput.addEventListener('blur', checkEmailEvent);
-signInBtn.addEventListener('click', testSignIn);
+document.querySelector('form').addEventListener('submit',(event) => {
+  event.preventDefault();
+  testSignIn();
+});
 document.querySelector('.eye').addEventListener('click', togglePasswordVisibilityEvent);
 document.addEventListener('DOMContentLoaded', checkAccessToken);

--- a/js/signup.js
+++ b/js/signup.js
@@ -1,7 +1,8 @@
 import { checkEmail, checkEmpty, checkPassword } from "./check.js";
 import showError from "./showError.js";
 import deleteError from "./deleteError.js";
-import showPassword from "./showPassword.js";
+import togglePasswordVisibility from "./togglePasswordVisibility.js";
+import { TEST_EMAIL } from "../constant/constant.js";
 
 const emailInput = document.querySelector('#email');
 const passwordInput = document.querySelector('#password');
@@ -20,15 +21,15 @@ const confirmPassword = (passwordTag, passwordCheckTag) => {
 }
 
 const checkEmptyEvent = (e) => {
-  if(inputList.includes(e.target)) checkEmpty(e.target);
+  if(e.target === emailInput || e.target === passwordInput || e.target === passwordCheckInput) checkEmpty(e.target);
 }
 
 const deleteErrorEvent = (e) => {
-  if(inputList.includes(e.target)) deleteError(e.target);
+  if(e.target === emailInput || e.target === passwordInput || e.target === passwordCheckInput) deleteError(e.target);
 }
 
 const checkEmailEvent = (e) => {
-  if(e.target === document.querySelector('#email')) checkEmail(e.target);
+  if(e.target.id === 'email') checkEmail(e.target);
 }
 
 const checkPasswordEvent = (e) => {
@@ -39,13 +40,13 @@ const confirmPasswordEvent = (e) => {
   if(e.target.id === 'password-check') confirmPassword(passwordInput, passwordCheckInput);
 }
 
-const showPasswordEvent = (e) => {
-  if(e.target.classList.contains('eye')) showPassword(e.target);
+const togglePasswordVisibilityEvent = (e) => {
+  if(e.target.classList.contains('eye')) togglePasswordVisibility(e.target);
 }
 
 const testEmail = (e) => {
   if(e.target === emailInput) {
-    if(e.target.value === 'test@codeit.com') {
+    if(e.target.value === TEST_EMAIL) {
       showError(e.target, '이미 사용 중인 이메일입니다.');
     }
   }
@@ -65,19 +66,23 @@ const testSignUp = (e) => {
   }
 }
 
-inputList.forEach((element) => {element.addEventListener('focusout', checkEmptyEvent)});
-inputList.forEach((element) => {element.addEventListener('focusin', deleteErrorEvent)});
+emailInput.addEventListener('focusout', checkEmptyEvent);
+passwordInput.addEventListener('focusout', checkEmptyEvent);
+passwordCheckInput.addEventListener('focusout', checkEmptyEvent);
+emailInput.addEventListener('focusin', deleteErrorEvent);
+passwordInput.addEventListener('focusin', deleteErrorEvent);
+passwordCheckInput.addEventListener('focusin', deleteErrorEvent);
 emailInput.addEventListener('input', checkEmailEvent);
-emailInput.addEventListener('blur', checkEmailEvent);
+emailInput.addEventListener('focusout', checkEmailEvent);
 emailInput.addEventListener('focusout', testEmail);
 emailInput.addEventListener('input', testEmail);
 passwordCheckInput.addEventListener('focusout', confirmPasswordEvent);
 passwordInput.addEventListener('focusout', checkPasswordEvent);
 passwordInput.addEventListener('input', checkPasswordEvent);
-document.body.addEventListener('click', showPasswordEvent);
 signUpBtn.addEventListener('click', testSignUp);
 document.addEventListener('keydown', function (e) {
   if (e.key === 'Enter' || e.keyCode === 13) {
     document.querySelector('.signup--btn').click();
   }
 });
+document.querySelectorAll('.eye').forEach((eyeIconElement) => eyeIconElement.addEventListener('click', togglePasswordVisibilityEvent));

--- a/js/signup.js
+++ b/js/signup.js
@@ -1,4 +1,4 @@
-import { checkEmail, checkEmpty, checkPassword } from "./check.js";
+import { checkAccessToken, checkEmail, checkEmpty, checkPassword } from "./check.js";
 import showError from "./showError.js";
 import deleteError from "./deleteError.js";
 import togglePasswordVisibility from "./togglePasswordVisibility.js";
@@ -7,7 +7,6 @@ import { API_URL } from "../constant/constant.js";
 const emailInput = document.querySelector('#email');
 const passwordInput = document.querySelector('#password');
 const passwordCheckInput = document.querySelector('#password-check');
-const inputList = Array.from(document.querySelectorAll('input'));
 const signUpBtn = document.querySelector('.signup--btn');
 
 const confirmPassword = (passwordTag, passwordCheckTag) => {
@@ -80,7 +79,11 @@ const checkSignUp = async(emailInputElement, passwordInputElement) => {
         password: passwordInputElement.value
       })
     });
-    if(response.ok) window.location.href = './folder.html';
+    if(response.ok) {
+      window.location.href = './folder.html';
+      const { data } = await response.json();
+      localStorage.setItem('accessToken', data.accessToken);
+    }
   } catch(error) {
     alert(error);
   }
@@ -93,7 +96,6 @@ const testSignUp = (e) => {
       checkEmailDuplication(emailInput);
       checkSignUp(emailInput, passwordInput);
     } else {
-      inputList.forEach( element => checkEmpty(element));
       checkEmpty(emailInput);
       checkEmpty(passwordInput);
       checkEmpty(passwordCheckInput);
@@ -124,3 +126,4 @@ document.addEventListener('keydown', function (e) {
   }
 });
 document.querySelectorAll('.eye').forEach((eyeIconElement) => eyeIconElement.addEventListener('click', togglePasswordVisibilityEvent));
+document.addEventListener('DOMContentLoaded', checkAccessToken);

--- a/js/signup.js
+++ b/js/signup.js
@@ -19,35 +19,35 @@ const confirmPassword = (passwordTag, passwordCheckTag) => {
   }
 }
 
-const checkEmptyEvent = (e) => {
-  if(e.target === emailInput || e.target === passwordInput || e.target === passwordCheckInput) checkEmpty(e.target);
-}
+// const checkEmptyEvent = (e) => {
+//   if(e.target === emailInput || e.target === passwordInput || e.target === passwordCheckInput) checkEmpty(e.target);
+// }
 
-const deleteErrorEvent = (e) => {
-  if(e.target === emailInput || e.target === passwordInput || e.target === passwordCheckInput) deleteError(e.target);
-}
+// const deleteErrorEvent = (e) => {
+//   if(e.target === emailInput || e.target === passwordInput || e.target === passwordCheckInput) deleteError(e.target);
+// }
 
-const checkEmailEvent = (e) => {
-  if(e.target.id === 'email') checkEmail(e.target);
-}
+// const checkEmailEvent = (e) => {
+//   if(e.target.id === 'email') checkEmail(e.target);
+// }
 
-const checkPasswordEvent = (e) => {
-  if(e.target.id === 'password') checkPassword(e.target);
-}
+// const checkPasswordEvent = (e) => {
+//   if(e.target.id === 'password') checkPassword(e.target);
+// }
 
-const confirmPasswordEvent = (e) => {
-  if(e.target.id === 'password-check') confirmPassword(passwordInput, passwordCheckInput);
-}
+// const confirmPasswordEvent = (e) => {
+//   if(e.target.id === 'password-check') confirmPassword(passwordInput, passwordCheckInput);
+// }
 
 const togglePasswordVisibilityEvent = (e) => {
   if(e.target.classList.contains('eye')) togglePasswordVisibility(e.target);
 }
 
-const testEmail = (e) => {
-  if(e.target === emailInput) {
-    checkEmailDuplication(emailInput);
-  }
-};
+// const testEmail = (e) => {
+//   if(e.target === emailInput) {
+//     checkEmailDuplication(emailInput);
+//   }
+// };
 
 const checkEmailDuplication = async(emailInputElement) => {
   if(emailInputElement.value === '') return;
@@ -106,19 +106,76 @@ const testSignUp = (e) => {
   }
 }
 
-emailInput.addEventListener('focusout', checkEmptyEvent);
-passwordInput.addEventListener('focusout', checkEmptyEvent);
-passwordCheckInput.addEventListener('focusout', checkEmptyEvent);
-emailInput.addEventListener('focusin', deleteErrorEvent);
-passwordInput.addEventListener('focusin', deleteErrorEvent);
-passwordCheckInput.addEventListener('focusin', deleteErrorEvent);
-emailInput.addEventListener('input', checkEmailEvent);
-emailInput.addEventListener('focusout', checkEmailEvent);
-emailInput.addEventListener('focusout', testEmail);
-emailInput.addEventListener('input', testEmail);
-passwordCheckInput.addEventListener('focusout', confirmPasswordEvent);
-passwordInput.addEventListener('focusout', checkPasswordEvent);
-passwordInput.addEventListener('input', checkPasswordEvent);
+const handleEmailInputFocusOutEvent = (e) => {
+  if(e.target === emailInput){
+    checkEmpty(emailInput);
+    checkEmail(emailInput);
+    checkEmailDuplication(emailInput);
+  }
+};
+const handleEmailInputFocusInEvent = (e) => {
+  if(e.target === emailInput){
+    deleteError(emailInput);
+  }
+};
+const handleEmailInputInputEvent = (e) => {
+  if(e.target === emailInput){
+    checkEmail(emailInput);
+    checkEmailDuplication(emailInput);
+  }
+};
+const handlePasswordInputFocusOutEvent = (e) => {
+  if(e.target === passwordInput) {
+    checkEmpty(passwordInput);
+    checkPassword(passwordInput);
+  }
+};
+const handlePasswordInputFocusInEvent = (e) => {
+  if(e.target === passwordInput) {
+    deleteError(passwordInput);
+  }
+};
+const handlePasswordInputInputEvent = (e) => {
+  if(e.target === passwordInput) {
+    checkPassword(passwordInput);
+  }
+};
+const handlePasswordCheckInputFocusOutEvent = (e) => {
+  if(e.target === passwordCheckInput) {
+    checkEmpty(passwordCheckInput);
+    confirmPassword(passwordInput, passwordCheckInput);
+  }
+};
+const handlePasswordCheckInputFocusInEvent = (e) => {
+  if(e.target === passwordCheckInput) {
+    deleteError(passwordCheckInput);
+  }
+};
+
+emailInput.addEventListener('focusout', handleEmailInputFocusOutEvent);
+emailInput.addEventListener('focusin', handleEmailInputFocusInEvent);
+emailInput.addEventListener('input', handleEmailInputInputEvent);
+passwordInput.addEventListener('focusout', handlePasswordInputFocusOutEvent);
+passwordInput.addEventListener('focusin', handlePasswordInputFocusInEvent);
+passwordInput.addEventListener('input', handlePasswordInputInputEvent);
+passwordCheckInput.addEventListener('focusout', handlePasswordCheckInputFocusOutEvent);
+passwordCheckInput.addEventListener('focusin', handlePasswordCheckInputFocusInEvent);
+
+
+
+// emailInput.addEventListener('focusout', checkEmptyEvent);
+// emailInput.addEventListener('focusout', checkEmailEvent);
+// emailInput.addEventListener('focusout', testEmail);
+// emailInput.addEventListener('focusin', deleteErrorEvent);
+// emailInput.addEventListener('input', checkEmailEvent);
+// emailInput.addEventListener('input', testEmail);
+// passwordInput.addEventListener('focusout', checkEmptyEvent);
+// passwordInput.addEventListener('focusout', checkPasswordEvent);
+// passwordInput.addEventListener('focusin', deleteErrorEvent);
+// passwordInput.addEventListener('input', checkPasswordEvent);
+// passwordCheckInput.addEventListener('focusout', checkEmptyEvent);
+// passwordCheckInput.addEventListener('focusout', confirmPasswordEvent);
+// passwordCheckInput.addEventListener('focusin', deleteErrorEvent);
 signUpBtn.addEventListener('click', testSignUp);
 document.addEventListener('keydown', function (e) {
   if (e.key === 'Enter' || e.keyCode === 13) {

--- a/js/signup.js
+++ b/js/signup.js
@@ -2,7 +2,7 @@ import { checkEmail, checkEmpty, checkPassword } from "./check.js";
 import showError from "./showError.js";
 import deleteError from "./deleteError.js";
 import togglePasswordVisibility from "./togglePasswordVisibility.js";
-import { TEST_EMAIL } from "../constant/constant.js";
+import { API_URL } from "../constant/constant.js";
 
 const emailInput = document.querySelector('#email');
 const passwordInput = document.querySelector('#password');
@@ -46,19 +46,57 @@ const togglePasswordVisibilityEvent = (e) => {
 
 const testEmail = (e) => {
   if(e.target === emailInput) {
-    if(e.target.value === TEST_EMAIL) {
-      showError(e.target, '이미 사용 중인 이메일입니다.');
-    }
+    checkEmailDuplication(emailInput);
   }
 };
+
+const checkEmailDuplication = async(emailInputElement) => {
+  if(emailInputElement.value === '') return;
+  try{
+    const response = await fetch(`${API_URL}/check-email`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        email: emailInputElement.value,
+      })
+    });
+    if(!response.ok) showError(emailInput, '이미 사용 중인 이메일입니다.');
+  } catch (error) {
+    alert(error);
+  }
+}
+
+const checkSignUp = async(emailInputElement, passwordInputElement) => {
+  try{
+    const response = await fetch(`${API_URL}/sign-up`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        email: emailInputElement.value,
+        password: passwordInputElement.value
+      })
+    });
+    if(response.ok) window.location.href = './folder.html';
+  } catch(error) {
+    alert(error);
+  }
+}
 
 const testSignUp = (e) => {
   e.preventDefault();
   if(e.target === document.querySelector('.signup--btn')) {
     if(checkEmail(emailInput) && checkPassword(passwordInput) && confirmPassword(passwordInput, passwordCheckInput)){
-      window.location.href = './folder.html';
+      checkEmailDuplication(emailInput);
+      checkSignUp(emailInput, passwordInput);
     } else {
       inputList.forEach( element => checkEmpty(element));
+      checkEmpty(emailInput);
+      checkEmpty(passwordInput);
+      checkEmpty(passwordCheckInput);
       checkEmail(emailInput);
       checkPassword(passwordInput);
       confirmPassword(passwordInput, passwordCheckInput);

--- a/js/signup.js
+++ b/js/signup.js
@@ -7,16 +7,13 @@ import { API_URL } from "../constant/constant.js";
 const emailInput = document.querySelector('#email');
 const passwordInput = document.querySelector('#password');
 const passwordCheckInput = document.querySelector('#password-check');
-const signUpBtn = document.querySelector('.signup--btn');
 
 const confirmPassword = (passwordTag, passwordCheckTag) => {
   if(passwordTag.value === passwordCheckTag.value) return true;
-  else {
-    if(passwordCheckTag.value === '') return;
-    if(passwordCheckTag.parentNode.lastChild.className ==='error-message') return;
-    showError(passwordCheckTag, '비밀번호가 일치하지 않아요.');
-    return false;
-  }
+  if(passwordCheckTag.value === '') return false;
+  if(passwordCheckTag.parentNode.querySelector('.error-message')) return false;
+  showError(passwordCheckTag, '비밀번호가 일치하지 않아요.');
+  return false;
 }
 
 // const checkEmptyEvent = (e) => {
@@ -42,12 +39,6 @@ const confirmPassword = (passwordTag, passwordCheckTag) => {
 const togglePasswordVisibilityEvent = (e) => {
   if(e.target.classList.contains('eye')) togglePasswordVisibility(e.target);
 }
-
-// const testEmail = (e) => {
-//   if(e.target === emailInput) {
-//     checkEmailDuplication(emailInput);
-//   }
-// };
 
 const checkEmailDuplication = async(emailInputElement) => {
   if(emailInputElement.value === '') return;
@@ -89,20 +80,17 @@ const checkSignUp = async(emailInputElement, passwordInputElement) => {
   }
 }
 
-const testSignUp = (e) => {
-  e.preventDefault();
-  if(e.target === document.querySelector('.signup--btn')) {
-    if(checkEmail(emailInput) && checkPassword(passwordInput) && confirmPassword(passwordInput, passwordCheckInput)){
-      checkEmailDuplication(emailInput);
-      checkSignUp(emailInput, passwordInput);
-    } else {
-      checkEmpty(emailInput);
-      checkEmpty(passwordInput);
-      checkEmpty(passwordCheckInput);
-      checkEmail(emailInput);
-      checkPassword(passwordInput);
-      confirmPassword(passwordInput, passwordCheckInput);
-    }
+const testSignUp = () => {
+  if(checkEmail(emailInput) && checkPassword(passwordInput) && confirmPassword(passwordInput, passwordCheckInput)){
+    checkEmailDuplication(emailInput);
+    checkSignUp(emailInput, passwordInput);
+  } else {
+    checkEmpty(emailInput);
+    checkEmpty(passwordInput);
+    checkEmpty(passwordCheckInput);
+    checkEmail(emailInput);
+    checkPassword(passwordInput);
+    confirmPassword(passwordInput, passwordCheckInput);
   }
 }
 
@@ -176,7 +164,10 @@ passwordCheckInput.addEventListener('focusin', handlePasswordCheckInputFocusInEv
 // passwordCheckInput.addEventListener('focusout', checkEmptyEvent);
 // passwordCheckInput.addEventListener('focusout', confirmPasswordEvent);
 // passwordCheckInput.addEventListener('focusin', deleteErrorEvent);
-signUpBtn.addEventListener('click', testSignUp);
+document.querySelector('form').addEventListener('submit',(event) => {
+  event.preventDefault();
+  testSignUp();
+});
 document.addEventListener('keydown', function (e) {
   if (e.key === 'Enter' || e.keyCode === 13) {
     document.querySelector('.signup--btn').click();

--- a/js/togglePasswordVisibility.js
+++ b/js/togglePasswordVisibility.js
@@ -1,6 +1,6 @@
-const showPassword = (tag) => {
-  const eyeIcon = tag;
-  const passwordInput = tag.parentNode.children[1];
+const togglePasswordVisibility = (eyeIconElement) => {
+  const eyeIcon = eyeIconElement;
+  const passwordInput = eyeIconElement.parentNode.children[1];
   eyeIcon.classList.toggle('eye-off');
   eyeIcon.classList.toggle('eye-on');
   if(eyeIcon.classList.contains('eye-off')){
@@ -15,4 +15,4 @@ const showPassword = (tag) => {
   }
 }
 
-export default showPassword;
+export default togglePasswordVisibility;

--- a/signin.html
+++ b/signin.html
@@ -36,7 +36,7 @@
             <img src="./assets/icon/eye-off.svg" alt="eye-off" class="eye-off eye">
           </div>
         </div>
-        <button class="account--btn btn signin--btn" type="button">로그인</button>
+        <button class="account--btn btn signin--btn" type="submit">로그인</button>
       </form>
     </div>
     <div class="social-login">

--- a/signup.html
+++ b/signup.html
@@ -41,7 +41,7 @@
             <img src="./assets/icon/eye-on.svg" alt="eye-on" class="eye-on eye">
           </div>
         </div>
-        <button class="account--btn btn signup--btn" type="button">회원가입</button>
+        <button class="account--btn btn signup--btn" type="submit">회원가입</button>
       </form>
     </div>
     <div class="social-login">


### PR DESCRIPTION
## 요구사항

### 기본

- [x]  https://bootcamp-api.codeit.kr/docs 에 명세된 “/api/sign-in”으로 { “email”: “test@codeit.com”, “password”: “sprint101” } POST 요청해서 성공 응답을 받고 “/folder”로 이동하나요?
- [x]  이메일 input에서 “test@codeit.com”으로 “/api/check-email” 이메일 중복 확인 POST 요청하면 이메일 중복 에러를 확인할 수 있나요?
- [x]  유효한 회원가입 형식의 경우 “/api/sign-up” POST 요청하고 성공 응답을 받으면 “/folder”로 이동하나요?

### 심화

- [x]  로그인/회원가입시 성공 응답으로 받은 accessToken을 로컬 스토리지에 저장했나요?
- [x]  로그인/회원가입 페이지에 접근시 로컬 스토리지에 accessToken이 있는 경우 “/folder” 페이지로 이동하나요?

## 주요 변경사항

- API를 활용한 로그인/회원가입 기능 구현 및 회원가입에서 이메일 중복확인 기능 추가
- 성공적인 로그인/회원가입 시도일 경우 accessToken을 로컬스토리지에 저장하고 로컬스토리지에 accessToken이 있을 시 자동으로 로그인 기능 추가


## 멘토에게

- signup.js에서 이벤트 할당 부분이 너무 길어져서 이벤트의 종류가 같은 것끼리 묶은 함수를 만들어서 각 이벤트 별로 할당했는데 뭐가 더 좋은 방법인지 모르겠습니다. 아마 페이지 하나에 이벤트가 여러개이다보니까 생기는 문제 같은데 컴포넌트 별 개발할 시 좀 덜 하리라 생각합니다. 그래도 저런 경우 이벤트를 어떤 식으로 할당하는게 좋은지 궁금합니다.(signup에서 주석처리된 부분처럼 하는게 좋은지 변경한 부분처럼 하는게 좋은지)
- 로그인 페이지에 접근할 때 accessToken이 로컬스토리지에 존재할 경우 로그인페이지에 들어갔다가 바로 /folder로 이동이 되는데 아예 로그인 페이지를 보이지 않고 바로 /folder로 이동하려고 한다면 index.html에서 로그인버튼에 이벤트를 줘야 할까요?
- 로그인/회원가입 기능을 구현할 때 api를 사용하기 위해서 async/await 구문과 try/catch 구문을 사용했는데 여기서 try부분에서 response.ok에 따라 성공과 실패시 에러메시지를 보여주는 부분을 처리하고 catch에서는 별도로 처리하지 않았는데 실패 시 에러메시지를 보여주는 부분을 catch에서 처리하는게 좋은가요? 아니면 네트워크 오류 및 기타 오류 등의 처리만 catch에서 하는게 좋은가요?
- Part2 기간에도 잘 부탁드립니다.

