### PR TITLE
[김민희]week14

### DIFF
--- a/pages/Signin/index.tsx
+++ b/pages/Signin/index.tsx
@@ -1,0 +1,20 @@
+import Head from "next/head";
+import { SignLayout } from "@/src/page-layout/SigninLayout";
+import { ROUTE } from "@/src/sharing/util";
+
+const SignInPage = () => {
+  return (
+    <SignLayout
+      header={
+        <Head
+          message="회원이 아니신가요?"
+          link={{ text: "회원 가입하기", href: ROUTE.회원가입 }}
+        />
+      }
+      form={<SignInForm />}
+      oauth={<Oauth description="소셜 로그인" />}
+    />
+  );
+};
+
+export default SignInPage;

--- a/pages/shared/[id].tsx
+++ b/pages/shared/[id].tsx
@@ -10,16 +10,25 @@ import { useSearchLink } from "@/src/link/util-search-link/useSearchLink";
 const SharedPage = () => {
   const { data } = useGetFolder();
   const { profileImage, ownerName, folderName, links } = data || {};
-  const { searchValue, handleChange, handleCloseClick, result } = useSearchLink(links);
+  const { searchValue, handleChange, handleCloseClick, result } =
+    useSearchLink(links);
 
   return (
     <Layout>
       <SharedLayout
         folderInfo={
-          <FolderInfo profileImage={profileImage} ownerName={ownerName} folderName={folderName} />
+          <FolderInfo
+            profileImage={profileImage}
+            ownerName={ownerName}
+            folderName={folderName}
+          />
         }
         searchBar={
-          <SearchBar value={searchValue} onChange={handleChange} onCloseClick={handleCloseClick} />
+          <SearchBar
+            value={searchValue}
+            onChange={handleChange}
+            onCloseClick={handleCloseClick}
+          />
         }
         cardList={
           <CardList>


### PR DESCRIPTION
## 요구사항

### 기본

- [x] [링크 공유 페이지] 링크 공유 페이지의 url path를 ‘/shared’에서 ‘/shared/{folderId}’로 변경했나요?


- [ ] [링크 공유 페이지] 폴더의 정보는 ‘/api/folders/{folderId}’, 폴더 소유자의 정보는 ‘/api/users/{userId}’를 활용했나요?


- [ ] [링크 공유 페이지] 링크 공유 페이지에서 폴더의 링크 데이터는 ‘/api/users/{userId}/links?folderId={folderId}’를 사용했나요?


- [ ] [폴더 페이지] 폴더 페이지에서 유저가 access token이 없는 경우 ‘/signin’페이지로 이동하나요?


- [ ] [폴더 페이지] 폴더 페이지의 url path가 ‘/folder’일 경우 폴더 목록에서 “전체” 가 선택되어 있고, ‘/folder/{folderId}’일 경우 폴더 목록에서 {folderId} 에 해당하는 폴더가 선택되어 있고 폴더에 있는 링크들을 볼 수 있나요?


- [ ] [폴더 페이지] 폴더 페이지에서 현재 유저의 폴더 목록 데이터를 받아올 때 ‘/api/folders’를 활용했나요?


- [ ] [폴더 페이지] 폴더 페이지에서 전체 링크 데이터를 받아올 때 ‘/api/links’, 특정 폴더의 링크를 받아올 때 ‘/api/links?folderId=1’를 활용했나요?


- [ ] [상단  네비게이션] 유효한 access token이 있는 경우 ‘/api/users’로 현재 로그인한 유저 정보를 받아 상단 네비게이션 유저 프로필을 보여주나요?


### 심화

- [ ] [심화] 리퀘스트 헤더에 인증 토큰을 첨부할 때 axios interceptors 또는 이와 유사한 기능을 활용 했나요?

## 주요 변경사항

- 
-



## 멘토에게

- 나머지 요구사항은 다시 진행할 예정입니다!
-
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
